### PR TITLE
Metal Shader (uniform, attribute, signature matching)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,11 +16,7 @@ cmake_minimum_required(VERSION 2.8)
 project(SPIRV-Cross)
 enable_testing()
 
-option(SPIRV_CROSS_EXCEPTIONS_TO_ASSERTIONS "Instead of throwing exceptions assert. Only applies to the library targets" OFF)
-
-if(SPIRV_CROSS_EXCEPTIONS_TO_ASSERTIONS)
-	add_definitions(-DSPIRV_CROSS_EXCEPTIONS_TO_ASSERTIONS)
-endif()
+option(SPIRV_CROSS_EXCEPTIONS_TO_ASSERTIONS "Instead of throwing exceptions assert" OFF)
 
 if(${CMAKE_GENERATOR} MATCHES "Makefile")
   if(${CMAKE_CURRENT_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_BINARY_DIR})
@@ -56,30 +52,35 @@ target_link_libraries(spirv-cross-msl spirv-cross-glsl)
 target_link_libraries(spirv-cross-cpp spirv-cross-glsl)
 target_include_directories(spirv-cross-core PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
+set(spirv-compiler-options "")
+set(spirv-compiler-defines "")
+
+if(SPIRV_CROSS_EXCEPTIONS_TO_ASSERTIONS)
+  set(spirv-compiler-defines ${spirv-compiler-defines} SPIRV_CROSS_EXCEPTIONS_TO_ASSERTIONS)
+endif()
+
 # To specify special debug or optimization options, use
 # -DCMAKE_CXX_COMPILE_FLAGS
 # However, we require the C++11 dialect.
 if (NOT "${MSVC}")
-  set(spirv-compiler-options -std=c++11 -Wall -Wextra -Werror -Wshadow)
-  set(spirv-compiler-defines __STDC_LIMIT_MACROS)
+  set(spirv-compiler-options ${spirv-compiler-options} -std=c++11 -Wall -Wextra -Werror -Wshadow)
+  set(spirv-compiler-defines ${spirv-compiler-defines} __STDC_LIMIT_MACROS)
 
-  set(spirv-exe-options ${spirv-compiler-options})
   if(SPIRV_CROSS_EXCEPTIONS_TO_ASSERTIONS)
     set(spirv-compiler-options ${spirv-compiler-options} -fno-exceptions)
   endif()
-
-  target_compile_options(spirv-cross-core PRIVATE ${spirv-compiler-options})
-  target_compile_options(spirv-cross-glsl PRIVATE ${spirv-compiler-options})
-  target_compile_options(spirv-cross-msl PRIVATE ${spirv-compiler-options})
-  target_compile_options(spirv-cross-cpp PRIVATE ${spirv-compiler-options})
-  target_compile_options(spirv-cross PRIVATE ${spirv-exe-options})
-  target_compile_definitions(spirv-cross-core PRIVATE ${spirv-compiler-defines})
-  target_compile_definitions(spirv-cross-glsl PRIVATE ${spirv-compiler-defines})
-  target_compile_definitions(spirv-cross-msl PRIVATE ${spirv-compiler-defines})
-  target_compile_definitions(spirv-cross-cpp PRIVATE ${spirv-compiler-defines})
-  target_compile_definitions(spirv-cross PRIVATE ${spirv-compiler-defines})
 endif()
 
+target_compile_options(spirv-cross-core PRIVATE ${spirv-compiler-options})
+target_compile_options(spirv-cross-glsl PRIVATE ${spirv-compiler-options})
+target_compile_options(spirv-cross-msl PRIVATE ${spirv-compiler-options})
+target_compile_options(spirv-cross-cpp PRIVATE ${spirv-compiler-options})
+target_compile_options(spirv-cross PRIVATE ${spirv-compiler-options})
+target_compile_definitions(spirv-cross-core PRIVATE ${spirv-compiler-defines})
+target_compile_definitions(spirv-cross-glsl PRIVATE ${spirv-compiler-defines})
+target_compile_definitions(spirv-cross-msl PRIVATE ${spirv-compiler-defines})
+target_compile_definitions(spirv-cross-cpp PRIVATE ${spirv-compiler-defines})
+target_compile_definitions(spirv-cross PRIVATE ${spirv-compiler-defines})
 
 # Set up tests, using only the simplest modes of the test_shaders
 # script.  You have to invoke the script manually to:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,12 @@ cmake_minimum_required(VERSION 2.8)
 project(SPIRV-Cross)
 enable_testing()
 
+option(SPIRV_CROSS_EXCEPTIONS_TO_ASSERTIONS "Instead of throwing exceptions assert. Only applies to the library targets" OFF)
+
+if(SPIRV_CROSS_EXCEPTIONS_TO_ASSERTIONS)
+	add_definitions(-DSPIRV_CROSS_EXCEPTIONS_TO_ASSERTIONS)
+endif()
+
 if(${CMAKE_GENERATOR} MATCHES "Makefile")
   if(${CMAKE_CURRENT_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_BINARY_DIR})
     message(FATAL_ERROR "Build out of tree to avoid overwriting Makefile")
@@ -56,17 +62,23 @@ target_include_directories(spirv-cross-core PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 if (NOT "${MSVC}")
   set(spirv-compiler-options -std=c++11 -Wall -Wextra -Werror -Wshadow)
   set(spirv-compiler-defines __STDC_LIMIT_MACROS)
+
+  set(spirv-exe-options ${spirv-compiler-options})
+  if(SPIRV_CROSS_EXCEPTIONS_TO_ASSERTIONS)
+    set(spirv-compiler-options ${spirv-compiler-options} -fno-exceptions)
+  endif()
+
   target_compile_options(spirv-cross-core PRIVATE ${spirv-compiler-options})
   target_compile_options(spirv-cross-glsl PRIVATE ${spirv-compiler-options})
   target_compile_options(spirv-cross-msl PRIVATE ${spirv-compiler-options})
   target_compile_options(spirv-cross-cpp PRIVATE ${spirv-compiler-options})
-  target_compile_options(spirv-cross PRIVATE ${spirv-compiler-options})
+  target_compile_options(spirv-cross PRIVATE ${spirv-exe-options})
   target_compile_definitions(spirv-cross-core PRIVATE ${spirv-compiler-defines})
   target_compile_definitions(spirv-cross-glsl PRIVATE ${spirv-compiler-defines})
   target_compile_definitions(spirv-cross-msl PRIVATE ${spirv-compiler-defines})
   target_compile_definitions(spirv-cross-cpp PRIVATE ${spirv-compiler-defines})
   target_compile_definitions(spirv-cross PRIVATE ${spirv-compiler-defines})
-endif(NOT "${MSVC}")
+endif()
 
 
 # Set up tests, using only the simplest modes of the test_shaders
@@ -80,5 +92,6 @@ if(${PYTHONINTERP_FOUND} AND ${PYTHON_VERSION_MAJOR} GREATER 2)
 	   COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_shaders.py
 		   ${CMAKE_CURRENT_SOURCE_DIR}/shaders)
 else()
-  message(WARNING "Testing disabled. Could not find python3")
+  message(WARNING "Testing disabled. Could not find python3. If you have python3 installed try running "
+		  "cmake with -DPYTHON_EXECUTABLE:FILEPATH=/path/to/python3 to help it find the executable")
 endif()

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ CXXFLAGS += -std=c++11 -Wall -Wextra -Wshadow -D__STDC_LIMIT_MACROS
 ifeq ($(DEBUG), 1)
 	CXXFLAGS += -O0 -g
 else
-	CXXFLAGS += -O2 -g
+	CXXFLAGS += -O2 -DNDEBUG
 endif
 
 all: $(TARGET)

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,10 @@ else
 	CXXFLAGS += -O2 -DNDEBUG
 endif
 
+ifeq ($(SPIRV_CROSS_EXCEPTIONS_TO_ASSERTIONS), 1)
+	CXXFLAGS += -DSPIRV_CROSS_EXCEPTIONS_TO_ASSERTIONS -fno-exceptions
+endif
+
 all: $(TARGET)
 
 -include $(DEPS)

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ However, most missing features are expected to be "trivial" improvements at this
 
 SPIRV-Cross has been tested on Linux, OSX and Windows.
 
+The make and CMake build flavors offer the option to treat exceptions as assertions. To disable exceptions for make just append SPIRV_CROSS_EXCEPTIONS_TO_ASSERTIONS=1 to the command line. For CMake append -DSPIRV_CROSS_EXCEPTIONS_TO_ASSERTIONS=ON. By default exceptions are enabled.
+
 ### Linux and macOS
 
 Just run `make` on the command line. A recent GCC (4.8+) or Clang (3.x+) compiler is required as SPIRV-Cross uses C++11 extensively.

--- a/main.cpp
+++ b/main.cpp
@@ -30,6 +30,17 @@ using namespace spv;
 using namespace spirv_cross;
 using namespace std;
 
+#ifdef SPIRV_CROSS_EXCEPTIONS_TO_ASSERTIONS
+#define THROW(x)                   \
+	do                             \
+	{                              \
+		fprintf(stderr, "%s.", x); \
+		exit(1);                   \
+	} while (0)
+#else
+#define THROW(x) runtime_error(x)
+#endif
+
 struct CLIParser;
 struct CLICallbacks
 {
@@ -53,7 +64,9 @@ struct CLIParser
 
 	bool parse()
 	{
+#ifndef SPIRV_CROSS_EXCEPTIONS_TO_ASSERTIONS
 		try
+#endif
 		{
 			while (argc && !ended_state)
 			{
@@ -69,7 +82,7 @@ struct CLIParser
 					auto itr = cbs.callbacks.find(next);
 					if (itr == ::end(cbs.callbacks))
 					{
-						throw logic_error("Invalid argument.\n");
+						THROW("Invalid argument");
 					}
 
 					itr->second(*this);
@@ -78,6 +91,7 @@ struct CLIParser
 
 			return true;
 		}
+#ifndef SPIRV_CROSS_EXCEPTIONS_TO_ASSERTIONS
 		catch (...)
 		{
 			if (cbs.error_handler)
@@ -86,6 +100,7 @@ struct CLIParser
 			}
 			return false;
 		}
+#endif
 	}
 
 	void end()
@@ -97,13 +112,13 @@ struct CLIParser
 	{
 		if (!argc)
 		{
-			throw logic_error("Tried to parse uint, but nothing left in arguments.\n");
+			THROW("Tried to parse uint, but nothing left in arguments");
 		}
 
 		uint32_t val = stoul(*argv);
 		if (val > numeric_limits<uint32_t>::max())
 		{
-			throw out_of_range("next_uint() out of range.\n");
+			THROW("next_uint() out of range");
 		}
 
 		argc--;
@@ -116,7 +131,7 @@ struct CLIParser
 	{
 		if (!argc)
 		{
-			throw logic_error("Tried to parse double, but nothing left in arguments.\n");
+			THROW("Tried to parse double, but nothing left in arguments");
 		}
 
 		double val = stod(*argv);
@@ -131,7 +146,7 @@ struct CLIParser
 	{
 		if (!argc)
 		{
-			throw logic_error("Tried to parse string, but nothing left in arguments.\n");
+			THROW("Tried to parse string, but nothing left in arguments");
 		}
 
 		const char *ret = *argv;

--- a/main.cpp
+++ b/main.cpp
@@ -215,9 +215,9 @@ static void print_resources(const Compiler &compiler, const char *tag, const vec
 		                                   compiler.get_storage_class(res.id) == StorageClassUniformConstant);
 		uint32_t fallback_id = !is_push_constant && is_block ? res.base_type_id : res.id;
 
-		size_t block_size = 0;
+		uint32_t block_size = 0;
 		if (is_sized_block)
-			block_size = compiler.get_declared_struct_size(compiler.get_type(res.base_type_id));
+			block_size = (uint32_t)compiler.get_declared_struct_size(compiler.get_type(res.base_type_id));
 
 		string array;
 		for (auto arr : type.array)
@@ -235,7 +235,7 @@ static void print_resources(const Compiler &compiler, const char *tag, const vec
 		if (mask & (1ull << DecorationInputAttachmentIndex))
 			fprintf(stderr, " (Attachment : %u)", compiler.get_decoration(res.id, DecorationInputAttachmentIndex));
 		if (is_sized_block)
-			fprintf(stderr, " (BlockSize : %zu bytes)", block_size);
+			fprintf(stderr, " (BlockSize : %u bytes)", block_size);
 		fprintf(stderr, "\n");
 	}
 	fprintf(stderr, "=============\n\n");

--- a/main.cpp
+++ b/main.cpp
@@ -234,6 +234,10 @@ static void print_resources(const Compiler &compiler, const char *tag, const vec
 			fprintf(stderr, " (Binding : %u)", compiler.get_decoration(res.id, DecorationBinding));
 		if (mask & (1ull << DecorationInputAttachmentIndex))
 			fprintf(stderr, " (Attachment : %u)", compiler.get_decoration(res.id, DecorationInputAttachmentIndex));
+		if (mask & (1ull << DecorationNonReadable))
+			fprintf(stderr, " writeonly");
+		if (mask & (1ull << DecorationNonWritable))
+			fprintf(stderr, " readonly");
 		if (is_sized_block)
 			fprintf(stderr, " (BlockSize : %u bytes)", block_size);
 		fprintf(stderr, "\n");

--- a/main.cpp
+++ b/main.cpp
@@ -215,7 +215,7 @@ static void print_resources(const Compiler &compiler, const char *tag, const vec
 		                                   compiler.get_storage_class(res.id) == StorageClassUniformConstant);
 		uint32_t fallback_id = !is_push_constant && is_block ? res.base_type_id : res.id;
 
-		uint32_t block_size = 0;
+		size_t block_size = 0;
 		if (is_sized_block)
 			block_size = compiler.get_declared_struct_size(compiler.get_type(res.base_type_id));
 
@@ -235,7 +235,7 @@ static void print_resources(const Compiler &compiler, const char *tag, const vec
 		if (mask & (1ull << DecorationInputAttachmentIndex))
 			fprintf(stderr, " (Attachment : %u)", compiler.get_decoration(res.id, DecorationInputAttachmentIndex));
 		if (is_sized_block)
-			fprintf(stderr, " (BlockSize : %u bytes)", block_size);
+			fprintf(stderr, " (BlockSize : %zu bytes)", block_size);
 		fprintf(stderr, "\n");
 	}
 	fprintf(stderr, "=============\n\n");

--- a/main.cpp
+++ b/main.cpp
@@ -217,7 +217,7 @@ static void print_resources(const Compiler &compiler, const char *tag, const vec
 
 		uint32_t block_size = 0;
 		if (is_sized_block)
-			block_size = (uint32_t)compiler.get_declared_struct_size(compiler.get_type(res.base_type_id));
+			block_size = uint32_t(compiler.get_declared_struct_size(compiler.get_type(res.base_type_id)));
 
 		string array;
 		for (auto arr : type.array)

--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -893,7 +893,6 @@ struct Meta
 		uint32_t input_attachment = 0;
 		uint32_t spec_id = 0;
 		bool builtin = false;
-		bool per_instance = false;
 	};
 
 	Decoration decoration;

--- a/spirv_common.hpp
+++ b/spirv_common.hpp
@@ -26,12 +26,16 @@ namespace spirv_cross
 {
 
 #ifdef SPIRV_CROSS_EXCEPTIONS_TO_ASSERTIONS
-[[noreturn]] inline void report_and_abort(const std::string &msg)
+#ifndef _MSC_VER
+[[noreturn]]
+#endif
+    inline void
+    report_and_abort(const std::string &msg)
 {
 #ifdef NDEBUG
 	(void)msg;
 #else
-	fprintf(stderr, "There was a compiler error: %s\n", std::string(msg).c_str());
+	fprintf(stderr, "There was a compiler error: %s\n", msg.c_str());
 #endif
 	abort();
 }

--- a/spirv_cpp.cpp
+++ b/spirv_cpp.cpp
@@ -116,8 +116,8 @@ void CompilerCPP::emit_push_constant_block(const SPIRVariable &var)
 	auto &type = get<SPIRType>(var.basetype);
 	auto &flags = meta[var.self].decoration.decoration_flags;
 	if ((flags & (1ull << DecorationBinding)) || (flags & (1ull << DecorationDescriptorSet)))
-		throw CompilerError("Push constant blocks cannot be compiled to GLSL with Binding or Set syntax. "
-		                    "Remap to location with reflection API first or disable these decorations.");
+		SPIRV_CROSS_THROW("Push constant blocks cannot be compiled to GLSL with Binding or Set syntax. "
+		                  "Remap to location with reflection API first or disable these decorations.");
 
 	emit_block_struct(type);
 	auto buffer_name = to_name(type.self);
@@ -298,7 +298,7 @@ string CompilerCPP::compile()
 	do
 	{
 		if (pass_count >= 3)
-			throw CompilerError("Over 3 compilation loops detected. Must be a bug!");
+			SPIRV_CROSS_THROW("Over 3 compilation loops detected. Must be a bug!");
 
 		resource_registrations.clear();
 		reset();
@@ -469,7 +469,7 @@ void CompilerCPP::emit_header()
 		break;
 
 	default:
-		throw CompilerError("Unsupported execution model.");
+		SPIRV_CROSS_THROW("Unsupported execution model.");
 	}
 
 	switch (execution.model)
@@ -506,6 +506,6 @@ void CompilerCPP::emit_header()
 		break;
 
 	default:
-		throw CompilerError("Unsupported execution model.");
+		SPIRV_CROSS_THROW("Unsupported execution model.");
 	}
 }

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -1001,6 +1001,12 @@ uint64_t Compiler::get_decoration_mask(uint32_t id) const
 	return dec.decoration_flags;
 }
 
+bool Compiler::is_decoration_set(uint32_t id, spv::Decoration decoration) const
+{
+    auto &dec = meta.at(id).decoration;
+    return (dec.decoration_flags & (1ull << DecorationLocation));
+}
+
 uint32_t Compiler::get_decoration(uint32_t id, Decoration decoration) const
 {
 	auto &dec = meta.at(id).decoration;

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -2398,8 +2398,8 @@ SPIREntryPoint &Compiler::get_entry_point()
 bool Compiler::interface_variable_exists_in_entry_point(uint32_t id) const
 {
 	auto &var = get<SPIRVariable>(id);
-	if (var.storage != StorageClassInput && var.storage != StorageClassOutput)
-		throw CompilerError("Only Input and Output variables are part of a shader linking interface.");
+	if (var.storage != StorageClassInput && var.storage != StorageClassOutput && var.storage != StorageClassUniformConstant)
+		throw CompilerError("Only Input, Output variables and Uniform constants are part of a shader linking interface.");
 
 	// This is to avoid potential problems with very old glslang versions which did
 	// not emit input/output interfaces properly.

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -1018,6 +1018,9 @@ uint32_t Compiler::get_decoration(uint32_t id, Decoration decoration) const
 		return dec.input_attachment;
 	case DecorationSpecId:
 		return dec.spec_id;
+	case DecorationNonWritable:
+	case DecorationNonReadable:
+		return 1;
 	default:
 		return 0;
 	}

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -890,7 +890,7 @@ uint32_t Compiler::get_member_decoration(uint32_t id, uint32_t index, Decoration
 	case DecorationSpecId:
 		return dec.spec_id;
 	default:
-		return 0;
+		return 1;
 	}
 }
 
@@ -1018,11 +1018,8 @@ uint32_t Compiler::get_decoration(uint32_t id, Decoration decoration) const
 		return dec.input_attachment;
 	case DecorationSpecId:
 		return dec.spec_id;
-	case DecorationNonWritable:
-	case DecorationNonReadable:
-		return 1;
 	default:
-		return 0;
+		return 1;
 	}
 }
 

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -794,7 +794,7 @@ void Compiler::set_name(uint32_t id, const std::string &name)
 		return;
 
 	// Functions in glslangValidator are mangled with name(<mangled> stuff.
-	// Normally, we would never see '(' in any legal indentifiers, so just strip them out.
+	// Normally, we would never see '(' in any legal identifiers, so just strip them out.
 	str = name.substr(0, name.find('('));
 
 	for (uint32_t i = 0; i < str.size(); i++)

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -2932,7 +2932,7 @@ void Compiler::analyze_variable_scope(SPIRFunction &entry)
 				if (potential == 0)
 					potential = block;
 				else
-					potential = -1u;
+					potential = ~(0u);
 			}
 			builder.add_block(block);
 		}
@@ -2959,7 +2959,7 @@ void Compiler::analyze_variable_scope(SPIRFunction &entry)
 		auto block = loop_variable.second;
 
 		// The variable was accessed in multiple continue blocks, ignore.
-		if (block == -1u || block == 0)
+		if (block == ~(0u) || block == 0)
 			continue;
 
 		// Dead code.

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -1438,17 +1438,6 @@ void Compiler::parse(const Instruction &instruction)
 		if (variable_storage_is_aliased(var))
 			aliased_variables.push_back(var.self);
 
-		// glslangValidator does not emit required qualifiers here.
-		// Solve this by making the image access as restricted as possible
-		// and loosen up if we need to.
-		auto &vartype = expression_type(id);
-		if (vartype.basetype == SPIRType::Image)
-		{
-			auto &flags = meta.at(id).decoration.decoration_flags;
-			flags |= 1ull << DecorationNonWritable;
-			flags |= 1ull << DecorationNonReadable;
-		}
-
 		break;
 	}
 

--- a/spirv_cross.cpp
+++ b/spirv_cross.cpp
@@ -33,7 +33,7 @@ Instruction::Instruction(const vector<uint32_t> &spirv, uint32_t &index)
 	count = (spirv[index] >> 16) & 0xffff;
 
 	if (count == 0)
-		throw CompilerError("SPIR-V instructions cannot consume 0 words. Invalid SPIR-V file.");
+		SPIRV_CROSS_THROW("SPIR-V instructions cannot consume 0 words. Invalid SPIR-V file.");
 
 	offset = index + 1;
 	length = count - 1;
@@ -41,7 +41,7 @@ Instruction::Instruction(const vector<uint32_t> &spirv, uint32_t &index)
 	index += count;
 
 	if (index > spirv.size())
-		throw CompilerError("SPIR-V instruction goes out of bounds.");
+		SPIRV_CROSS_THROW("SPIR-V instruction goes out of bounds.");
 }
 
 Compiler::Compiler(vector<uint32_t> ir)
@@ -328,7 +328,7 @@ const SPIRType &Compiler::expression_type(uint32_t id) const
 		return get<SPIRType>(get<SPIRUndef>(id).basetype);
 
 	default:
-		throw CompilerError("Cannot resolve expression type.");
+		SPIRV_CROSS_THROW("Cannot resolve expression type.");
 	}
 }
 
@@ -665,7 +665,7 @@ static string extract_string(const vector<uint32_t> &spirv, uint32_t offset)
 		}
 	}
 
-	throw CompilerError("String was not terminated before EOF");
+	SPIRV_CROSS_THROW("String was not terminated before EOF");
 }
 
 static bool is_valid_spirv_version(uint32_t version)
@@ -687,7 +687,7 @@ void Compiler::parse()
 {
 	auto len = spirv.size();
 	if (len < 5)
-		throw CompilerError("SPIRV file too small.");
+		SPIRV_CROSS_THROW("SPIRV file too small.");
 
 	auto s = spirv.data();
 
@@ -696,7 +696,7 @@ void Compiler::parse()
 		transform(begin(spirv), end(spirv), begin(spirv), [](uint32_t c) { return swap_endian(c); });
 
 	if (s[0] != MagicNumber || !is_valid_spirv_version(s[1]))
-		throw CompilerError("Invalid SPIRV format.");
+		SPIRV_CROSS_THROW("Invalid SPIRV format.");
 
 	uint32_t bound = s[3];
 	ids.resize(bound);
@@ -710,9 +710,9 @@ void Compiler::parse()
 		parse(i);
 
 	if (current_function)
-		throw CompilerError("Function was not terminated.");
+		SPIRV_CROSS_THROW("Function was not terminated.");
 	if (current_block)
-		throw CompilerError("Block was not terminated.");
+		SPIRV_CROSS_THROW("Block was not terminated.");
 }
 
 void Compiler::flatten_interface_block(uint32_t id)
@@ -722,24 +722,24 @@ void Compiler::flatten_interface_block(uint32_t id)
 	auto flags = meta.at(type.self).decoration.decoration_flags;
 
 	if (!type.array.empty())
-		throw CompilerError("Type is array of UBOs.");
+		SPIRV_CROSS_THROW("Type is array of UBOs.");
 	if (type.basetype != SPIRType::Struct)
-		throw CompilerError("Type is not a struct.");
+		SPIRV_CROSS_THROW("Type is not a struct.");
 	if ((flags & (1ull << DecorationBlock)) == 0)
-		throw CompilerError("Type is not a block.");
+		SPIRV_CROSS_THROW("Type is not a block.");
 	if (type.member_types.empty())
-		throw CompilerError("Member list of struct is empty.");
+		SPIRV_CROSS_THROW("Member list of struct is empty.");
 
 	uint32_t t = type.member_types[0];
 	for (auto &m : type.member_types)
 		if (t != m)
-			throw CompilerError("Types in block differ.");
+			SPIRV_CROSS_THROW("Types in block differ.");
 
 	auto &mtype = get<SPIRType>(t);
 	if (!mtype.array.empty())
-		throw CompilerError("Member type cannot be arrays.");
+		SPIRV_CROSS_THROW("Member type cannot be arrays.");
 	if (mtype.basetype == SPIRType::Struct)
-		throw CompilerError("Member type cannot be struct.");
+		SPIRV_CROSS_THROW("Member type cannot be struct.");
 
 	// Inherit variable name from interface block name.
 	meta.at(var.self).decoration.alias = meta.at(type.self).decoration.alias;
@@ -1112,7 +1112,7 @@ void Compiler::parse(const Instruction &instruction)
 	{
 		uint32_t cap = ops[0];
 		if (cap == CapabilityKernel)
-			throw CompilerError("Kernel capability not supported.");
+			SPIRV_CROSS_THROW("Kernel capability not supported.");
 		break;
 	}
 
@@ -1123,7 +1123,7 @@ void Compiler::parse(const Instruction &instruction)
 		if (ext == "GLSL.std.450")
 			set<SPIRExtension>(id, SPIRExtension::GLSL);
 		else
-			throw CompilerError("Only GLSL.std.450 extension interface supported.");
+			SPIRV_CROSS_THROW("Only GLSL.std.450 extension interface supported.");
 
 		break;
 	}
@@ -1362,7 +1362,7 @@ void Compiler::parse(const Instruction &instruction)
 
 		ptrbase = base;
 		if (ptrbase.pointer)
-			throw CompilerError("Cannot make pointer-to-pointer type.");
+			SPIRV_CROSS_THROW("Cannot make pointer-to-pointer type.");
 		ptrbase.pointer = true;
 		ptrbase.storage = static_cast<StorageClass>(ops[1]);
 
@@ -1425,7 +1425,7 @@ void Compiler::parse(const Instruction &instruction)
 		if (storage == StorageClassFunction)
 		{
 			if (!current_function)
-				throw CompilerError("No function currently in scope");
+				SPIRV_CROSS_THROW("No function currently in scope");
 			current_function->add_local_variable(id);
 		}
 		else if (storage == StorageClassPrivate || storage == StorageClassWorkgroup || storage == StorageClassOutput)
@@ -1460,9 +1460,9 @@ void Compiler::parse(const Instruction &instruction)
 	case OpPhi:
 	{
 		if (!current_function)
-			throw CompilerError("No function currently in scope");
+			SPIRV_CROSS_THROW("No function currently in scope");
 		if (!current_block)
-			throw CompilerError("No block currently in scope");
+			SPIRV_CROSS_THROW("No block currently in scope");
 
 		uint32_t result_type = ops[0];
 		uint32_t id = ops[1];
@@ -1554,7 +1554,7 @@ void Compiler::parse(const Instruction &instruction)
 				break;
 
 			default:
-				throw CompilerError("OpConstantComposite only supports 1, 2, 3 and 4 columns.");
+				SPIRV_CROSS_THROW("OpConstantComposite only supports 1, 2, 3 and 4 columns.");
 			}
 		}
 		else
@@ -1612,7 +1612,7 @@ void Compiler::parse(const Instruction &instruction)
 				break;
 
 			default:
-				throw CompilerError("OpConstantComposite only supports 1, 2, 3 and 4 components.");
+				SPIRV_CROSS_THROW("OpConstantComposite only supports 1, 2, 3 and 4 components.");
 			}
 		}
 
@@ -1629,7 +1629,7 @@ void Compiler::parse(const Instruction &instruction)
 		uint32_t type = ops[3];
 
 		if (current_function)
-			throw CompilerError("Must end a function before starting a new one!");
+			SPIRV_CROSS_THROW("Must end a function before starting a new one!");
 
 		current_function = &set<SPIRFunction>(id, res, type);
 		break;
@@ -1641,7 +1641,7 @@ void Compiler::parse(const Instruction &instruction)
 		uint32_t id = ops[1];
 
 		if (!current_function)
-			throw CompilerError("Must be in a function!");
+			SPIRV_CROSS_THROW("Must be in a function!");
 
 		current_function->add_parameter(type, id);
 		set<SPIRVariable>(id, type, StorageClassFunction);
@@ -1653,7 +1653,7 @@ void Compiler::parse(const Instruction &instruction)
 		if (current_block)
 		{
 			// Very specific error message, but seems to come up quite often.
-			throw CompilerError(
+			SPIRV_CROSS_THROW(
 			    "Cannot end a function before ending the current block.\n"
 			    "Likely cause: If this SPIR-V was created from glslang HLSL, make sure the entry point is valid.");
 		}
@@ -1666,7 +1666,7 @@ void Compiler::parse(const Instruction &instruction)
 	{
 		// OpLabel always starts a block.
 		if (!current_function)
-			throw CompilerError("Blocks cannot exist outside functions!");
+			SPIRV_CROSS_THROW("Blocks cannot exist outside functions!");
 
 		uint32_t id = ops[0];
 
@@ -1675,7 +1675,7 @@ void Compiler::parse(const Instruction &instruction)
 			current_function->entry_block = id;
 
 		if (current_block)
-			throw CompilerError("Cannot start a block before ending the current block.");
+			SPIRV_CROSS_THROW("Cannot start a block before ending the current block.");
 
 		current_block = &set<SPIRBlock>(id);
 		break;
@@ -1685,7 +1685,7 @@ void Compiler::parse(const Instruction &instruction)
 	case OpBranch:
 	{
 		if (!current_block)
-			throw CompilerError("Trying to end a non-existing block.");
+			SPIRV_CROSS_THROW("Trying to end a non-existing block.");
 
 		uint32_t target = ops[0];
 		current_block->terminator = SPIRBlock::Direct;
@@ -1697,7 +1697,7 @@ void Compiler::parse(const Instruction &instruction)
 	case OpBranchConditional:
 	{
 		if (!current_block)
-			throw CompilerError("Trying to end a non-existing block.");
+			SPIRV_CROSS_THROW("Trying to end a non-existing block.");
 
 		current_block->condition = ops[0];
 		current_block->true_block = ops[1];
@@ -1711,10 +1711,10 @@ void Compiler::parse(const Instruction &instruction)
 	case OpSwitch:
 	{
 		if (!current_block)
-			throw CompilerError("Trying to end a non-existing block.");
+			SPIRV_CROSS_THROW("Trying to end a non-existing block.");
 
 		if (current_block->merge == SPIRBlock::MergeNone)
-			throw CompilerError("Switch statement is not structured");
+			SPIRV_CROSS_THROW("Switch statement is not structured");
 
 		current_block->terminator = SPIRBlock::MultiSelect;
 
@@ -1734,7 +1734,7 @@ void Compiler::parse(const Instruction &instruction)
 	case OpKill:
 	{
 		if (!current_block)
-			throw CompilerError("Trying to end a non-existing block.");
+			SPIRV_CROSS_THROW("Trying to end a non-existing block.");
 		current_block->terminator = SPIRBlock::Kill;
 		current_block = nullptr;
 		break;
@@ -1743,7 +1743,7 @@ void Compiler::parse(const Instruction &instruction)
 	case OpReturn:
 	{
 		if (!current_block)
-			throw CompilerError("Trying to end a non-existing block.");
+			SPIRV_CROSS_THROW("Trying to end a non-existing block.");
 		current_block->terminator = SPIRBlock::Return;
 		current_block = nullptr;
 		break;
@@ -1752,7 +1752,7 @@ void Compiler::parse(const Instruction &instruction)
 	case OpReturnValue:
 	{
 		if (!current_block)
-			throw CompilerError("Trying to end a non-existing block.");
+			SPIRV_CROSS_THROW("Trying to end a non-existing block.");
 		current_block->terminator = SPIRBlock::Return;
 		current_block->return_value = ops[0];
 		current_block = nullptr;
@@ -1762,7 +1762,7 @@ void Compiler::parse(const Instruction &instruction)
 	case OpUnreachable:
 	{
 		if (!current_block)
-			throw CompilerError("Trying to end a non-existing block.");
+			SPIRV_CROSS_THROW("Trying to end a non-existing block.");
 		current_block->terminator = SPIRBlock::Unreachable;
 		current_block = nullptr;
 		break;
@@ -1771,7 +1771,7 @@ void Compiler::parse(const Instruction &instruction)
 	case OpSelectionMerge:
 	{
 		if (!current_block)
-			throw CompilerError("Trying to modify a non-existing block.");
+			SPIRV_CROSS_THROW("Trying to modify a non-existing block.");
 
 		current_block->next_block = ops[0];
 		current_block->merge = SPIRBlock::MergeSelection;
@@ -1782,7 +1782,7 @@ void Compiler::parse(const Instruction &instruction)
 	case OpLoopMerge:
 	{
 		if (!current_block)
-			throw CompilerError("Trying to modify a non-existing block.");
+			SPIRV_CROSS_THROW("Trying to modify a non-existing block.");
 
 		current_block->merge_block = ops[0];
 		current_block->continue_block = ops[1];
@@ -1802,7 +1802,7 @@ void Compiler::parse(const Instruction &instruction)
 	case OpSpecConstantOp:
 	{
 		if (length < 3)
-			throw CompilerError("OpSpecConstantOp not enough arguments.");
+			SPIRV_CROSS_THROW("OpSpecConstantOp not enough arguments.");
 
 		uint32_t result_type = ops[0];
 		uint32_t id = ops[1];
@@ -1816,7 +1816,7 @@ void Compiler::parse(const Instruction &instruction)
 	default:
 	{
 		if (!current_block)
-			throw CompilerError("Currently no block to insert opcode.");
+			SPIRV_CROSS_THROW("Currently no block to insert opcode.");
 
 		current_block->ops.push_back(instruction);
 		break;
@@ -2040,7 +2040,7 @@ uint32_t Compiler::type_struct_member_offset(const SPIRType &type, uint32_t inde
 	if (dec.decoration_flags & (1ull << DecorationOffset))
 		return dec.offset;
 	else
-		throw CompilerError("Struct member does not have Offset set.");
+		SPIRV_CROSS_THROW("Struct member does not have Offset set.");
 }
 
 uint32_t Compiler::type_struct_member_array_stride(const SPIRType &type, uint32_t index) const
@@ -2051,7 +2051,7 @@ uint32_t Compiler::type_struct_member_array_stride(const SPIRType &type, uint32_
 	if (dec.decoration_flags & (1ull << DecorationArrayStride))
 		return dec.array_stride;
 	else
-		throw CompilerError("Struct member does not have ArrayStride set.");
+		SPIRV_CROSS_THROW("Struct member does not have ArrayStride set.");
 }
 
 size_t Compiler::get_declared_struct_size(const SPIRType &type) const
@@ -2078,7 +2078,7 @@ size_t Compiler::get_declared_struct_member_size(const SPIRType &struct_type, ui
 		case SPIRType::Image:
 		case SPIRType::SampledImage:
 		case SPIRType::Sampler:
-			throw CompilerError("Querying size for object with opaque size.\n");
+			SPIRV_CROSS_THROW("Querying size for object with opaque size.\n");
 
 		default:
 			break;
@@ -2357,7 +2357,7 @@ SPIREntryPoint &Compiler::get_entry_point(const std::string &name)
 	            [&](const std::pair<uint32_t, SPIREntryPoint> &entry) -> bool { return entry.second.name == name; });
 
 	if (itr == end(entry_points))
-		throw CompilerError("Entry point does not exist.");
+		SPIRV_CROSS_THROW("Entry point does not exist.");
 
 	return itr->second;
 }
@@ -2369,7 +2369,7 @@ const SPIREntryPoint &Compiler::get_entry_point(const std::string &name) const
 	            [&](const std::pair<uint32_t, SPIREntryPoint> &entry) -> bool { return entry.second.name == name; });
 
 	if (itr == end(entry_points))
-		throw CompilerError("Entry point does not exist.");
+		SPIRV_CROSS_THROW("Entry point does not exist.");
 
 	return itr->second;
 }
@@ -2388,7 +2388,7 @@ bool Compiler::interface_variable_exists_in_entry_point(uint32_t id) const
 {
 	auto &var = get<SPIRVariable>(id);
 	if (var.storage != StorageClassInput && var.storage != StorageClassOutput)
-		throw CompilerError("Only Input and Output variables are part of a shader linking interface.");
+		SPIRV_CROSS_THROW("Only Input and Output variables are part of a shader linking interface.");
 
 	// This is to avoid potential problems with very old glslang versions which did
 	// not emit input/output interfaces properly.
@@ -2613,11 +2613,11 @@ bool Compiler::CombinedImageSamplerHandler::handle(Op opcode, const uint32_t *ar
 		bool separate_image = type.basetype == SPIRType::Image && type.image.sampled == 1;
 		bool separate_sampler = type.basetype == SPIRType::Sampler;
 		if (separate_image)
-			throw CompilerError(
+			SPIRV_CROSS_THROW(
 			    "Attempting to use arrays of separate images. This is not possible to statically remap to plain GLSL.");
 		if (separate_sampler)
-			throw CompilerError("Attempting to use arrays of separate samplers. This is not possible to statically "
-			                    "remap to plain GLSL.");
+			SPIRV_CROSS_THROW("Attempting to use arrays of separate samplers. This is not possible to statically "
+			                  "remap to plain GLSL.");
 		return true;
 	}
 

--- a/spirv_cross.hpp
+++ b/spirv_cross.hpp
@@ -136,6 +136,8 @@ public:
 	// Gets a bitmask for the decorations which are applied to ID.
 	// I.e. (1ull << spv::DecorationFoo) | (1ull << spv::DecorationBar)
 	uint64_t get_decoration_mask(uint32_t id) const;
+    
+    bool is_decoration_set(uint32_t id, spv::Decoration decoration) const;
 
 	// Gets the value for decorations which take arguments.
 	// If decoration doesn't exist or decoration is not recognized,

--- a/spirv_cross.hpp
+++ b/spirv_cross.hpp
@@ -483,7 +483,7 @@ protected:
 
 	void analyze_variable_scope(SPIRFunction &function);
 
-private:
+protected:
 	void parse();
 	void parse(const Instruction &i);
 

--- a/spirv_cross.hpp
+++ b/spirv_cross.hpp
@@ -327,7 +327,7 @@ protected:
 			return nullptr;
 
 		if (instr.offset + instr.length > spirv.size())
-			throw CompilerError("Compiler::stream() out of range.");
+			SPIRV_CROSS_THROW("Compiler::stream() out of range.");
 		return &spirv[instr.offset];
 	}
 	std::vector<uint32_t> spirv;

--- a/spirv_cross.hpp
+++ b/spirv_cross.hpp
@@ -138,8 +138,10 @@ public:
 	uint64_t get_decoration_mask(uint32_t id) const;
 
 	// Gets the value for decorations which take arguments.
+	// If the decoration is a boolean (i.e. spv::DecorationNonWritable),
+	// 1 will be returned.
 	// If decoration doesn't exist or decoration is not recognized,
-	// 0 will be returned.
+	// 0 will be returned. 
 	uint32_t get_decoration(uint32_t id, spv::Decoration decoration) const;
 
 	// Removes the decoration for a an ID.

--- a/spirv_cross.hpp
+++ b/spirv_cross.hpp
@@ -141,7 +141,7 @@ public:
 	// If the decoration is a boolean (i.e. spv::DecorationNonWritable),
 	// 1 will be returned.
 	// If decoration doesn't exist or decoration is not recognized,
-	// 0 will be returned. 
+	// 0 will be returned.
 	uint32_t get_decoration(uint32_t id, spv::Decoration decoration) const;
 
 	// Removes the decoration for a an ID.

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -2710,6 +2710,15 @@ string CompilerGLSL::to_function_args(uint32_t img, const SPIRType &, bool, bool
 	return farg_str;
 }
 
+// Some languages may have additional standard library functions whose names conflict
+// with a function defined in the body of the shader. Subclasses can override to rename
+// the function name defined in the shader to avoid conflict with the language standard
+// functions (eg. MSL includes saturate()).
+string CompilerGLSL::clean_func_name(string func_name)
+{
+    return func_name;
+}
+
 void CompilerGLSL::emit_glsl_op(uint32_t result_type, uint32_t id, uint32_t eop, const uint32_t *args, uint32_t)
 {
 	GLSLstd450 op = static_cast<GLSLstd450>(eop);
@@ -3638,7 +3647,7 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 
 		string funexpr;
 		vector<string> arglist;
-		funexpr += to_name(func) + "(";
+		funexpr += clean_func_name(to_name(func)) + "(";
 		for (uint32_t i = 0; i < length; i++)
 		{
 			// Do not pass in separate images or samplers if we're remapping
@@ -5359,11 +5368,11 @@ void CompilerGLSL::emit_function_prototype(SPIRFunction &func, uint64_t return_f
 
 	if (func.self == entry_point)
 	{
-		decl += "main";
+		decl += clean_func_name("main");
 		processing_entry_point = true;
 	}
 	else
-		decl += to_name(func.self);
+		decl += clean_func_name(to_name(func.self));
 
 	decl += "(";
 	vector<string> arglist;

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -2558,9 +2558,9 @@ void CompilerGLSL::emit_texture_op(const Instruction &i)
 
 // Returns the function name for a texture sampling function for the specified image and sampling characteristics.
 // For some subclasses, the function is a method on the specified image.
-string CompilerGLSL::to_function_name(uint32_t img, const SPIRType &imgtype, bool is_fetch, bool is_gather,
+string CompilerGLSL::to_function_name(uint32_t, const SPIRType &imgtype, bool is_fetch, bool is_gather,
                                       bool is_proj, bool has_array_offsets, bool has_offset, bool has_grad,
-                                      bool has_lod, bool has_dref)
+                                      bool has_lod, bool)
 {
 	string fname;
 
@@ -2589,8 +2589,8 @@ string CompilerGLSL::to_function_name(uint32_t img, const SPIRType &imgtype, boo
 }
 
 // Returns the function args for a texture sampling function for the specified image and sampling characteristics.
-string CompilerGLSL::to_function_args(uint32_t img, const SPIRType &imgtype, bool is_fetch, bool is_gather,
-                                      bool is_proj, uint32_t coord, uint32_t coord_components, uint32_t dref,
+string CompilerGLSL::to_function_args(uint32_t img, const SPIRType &, bool, bool,
+                                      bool, uint32_t coord, uint32_t coord_components, uint32_t dref,
                                       uint32_t grad_x, uint32_t grad_y, uint32_t lod, uint32_t coffset, uint32_t offset,
                                       uint32_t bias, uint32_t comp, uint32_t sample, bool *p_forward)
 {

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -2404,6 +2404,7 @@ void CompilerGLSL::emit_texture_op(const Instruction &i)
 	uint32_t comp = 0;
 	bool gather = false;
 	bool proj = false;
+	bool fetch = false;
 	const uint32_t *opt = nullptr;
 
 	switch (op)
@@ -2418,23 +2419,29 @@ void CompilerGLSL::emit_texture_op(const Instruction &i)
 	case OpImageSampleProjDrefImplicitLod:
 	case OpImageSampleProjDrefExplicitLod:
 		dref = ops[4];
-		proj = true;
 		opt = &ops[5];
 		length -= 5;
+		proj = true;
 		break;
 
 	case OpImageDrefGather:
 		dref = ops[4];
 		opt = &ops[5];
-		gather = true;
 		length -= 5;
+		gather = true;
 		break;
 
 	case OpImageGather:
 		comp = ops[4];
 		opt = &ops[5];
-		gather = true;
 		length -= 5;
+		gather = true;
+		break;
+
+	case OpImageFetch:
+		opt = &ops[4];
+		length -= 4;
+		fetch = true;
 		break;
 
 	case OpImageSampleProjImplicitLod:
@@ -2491,8 +2498,7 @@ void CompilerGLSL::emit_texture_op(const Instruction &i)
 
 	if (length)
 	{
-		flags = opt[0];
-		opt++;
+		flags = *opt++;
 		length--;
 	}
 
@@ -2514,35 +2520,56 @@ void CompilerGLSL::emit_texture_op(const Instruction &i)
 	test(sample, ImageOperandsSampleMask);
 
 	string expr;
-	string texop;
+	bool forward = false;
+	expr += to_function_name(img, imgtype, fetch, gather, proj, coffsets, (coffset || offset), (grad_x || grad_y), lod,
+	                         dref);
+	expr += "(";
+	expr += to_function_args(img, imgtype, fetch, gather, proj, coord, coord_components, dref, grad_x, grad_y, lod,
+	                         coffset, offset, bias, comp, sample, &forward);
+	expr += ")";
 
-	if (op == OpImageFetch)
-		texop += "texelFetch";
+	emit_op(result_type, id, expr, forward);
+}
+
+// Returns the function name for a texture sampling function for the specified image and sampling characteristics.
+// For some subclasses, the function is a method on the specified image.
+string CompilerGLSL::to_function_name(uint32_t img, const SPIRType &imgtype, bool is_fetch, bool is_gather,
+                                      bool is_proj, bool has_array_offsets, bool has_offset, bool has_grad,
+                                      bool has_lod, bool has_dref)
+{
+	string fname;
+
+	if (is_fetch)
+		fname += "texelFetch";
 	else
 	{
-		texop += "texture";
+		fname += "texture";
 
-		if (gather)
-			texop += "Gather";
-		if (coffsets)
-			texop += "Offsets";
-		if (proj)
-			texop += "Proj";
-		if (grad_x || grad_y)
-			texop += "Grad";
-		if (lod)
-			texop += "Lod";
+		if (is_gather)
+			fname += "Gather";
+		if (has_array_offsets)
+			fname += "Offsets";
+		if (is_proj)
+			fname += "Proj";
+		if (has_grad)
+			fname += "Grad";
+		if (has_lod)
+			fname += "Lod";
 	}
 
-	if (coffset || offset)
-		texop += "Offset";
+	if (has_offset)
+		fname += "Offset";
 
-	if (is_legacy())
-		texop = legacy_tex_op(texop, imgtype);
+	return is_legacy() ? legacy_tex_op(fname, imgtype) : fname;
+}
 
-	expr += texop;
-	expr += "(";
-	expr += to_expression(img);
+// Returns the function args for a texture sampling function for the specified image and sampling characteristics.
+string CompilerGLSL::to_function_args(uint32_t img, const SPIRType &imgtype, bool is_fetch, bool is_gather,
+                                      bool is_proj, uint32_t coord, uint32_t coord_components, uint32_t dref,
+                                      uint32_t grad_x, uint32_t grad_y, uint32_t lod, uint32_t coffset, uint32_t offset,
+                                      uint32_t bias, uint32_t comp, uint32_t sample, bool *p_forward)
+{
+	string farg_str = to_expression(img);
 
 	bool swizz_func = backend.swizzle_is_function;
 	auto swizzle = [swizz_func](uint32_t comps, uint32_t in_comps) -> const char * {
@@ -2578,84 +2605,84 @@ void CompilerGLSL::emit_texture_op(const Instruction &i)
 		// SPIR-V splits dref and coordinate.
 		if (coord_components == 4) // GLSL also splits the arguments in two.
 		{
-			expr += ", ";
-			expr += to_expression(coord);
-			expr += ", ";
-			expr += to_expression(dref);
+			farg_str += ", ";
+			farg_str += to_expression(coord);
+			farg_str += ", ";
+			farg_str += to_expression(dref);
 		}
 		else
 		{
 			// Create a composite which merges coord/dref into a single vector.
 			auto type = expression_type(coord);
 			type.vecsize = coord_components + 1;
-			expr += ", ";
-			expr += type_to_glsl_constructor(type);
-			expr += "(";
-			expr += coord_expr;
-			expr += ", ";
-			expr += to_expression(dref);
-			expr += ")";
+			farg_str += ", ";
+			farg_str += type_to_glsl_constructor(type);
+			farg_str += "(";
+			farg_str += coord_expr;
+			farg_str += ", ";
+			farg_str += to_expression(dref);
+			farg_str += ")";
 		}
 	}
 	else
 	{
-		expr += ", ";
-		expr += coord_expr;
+		farg_str += ", ";
+		farg_str += coord_expr;
 	}
 
 	if (grad_x || grad_y)
 	{
 		forward = forward && should_forward(grad_x);
 		forward = forward && should_forward(grad_y);
-		expr += ", ";
-		expr += to_expression(grad_x);
-		expr += ", ";
-		expr += to_expression(grad_y);
+		farg_str += ", ";
+		farg_str += to_expression(grad_x);
+		farg_str += ", ";
+		farg_str += to_expression(grad_y);
 	}
 
 	if (lod)
 	{
 		forward = forward && should_forward(lod);
-		expr += ", ";
-		expr += to_expression(lod);
+		farg_str += ", ";
+		farg_str += to_expression(lod);
 	}
 
 	if (coffset)
 	{
 		forward = forward && should_forward(coffset);
-		expr += ", ";
-		expr += to_expression(coffset);
+		farg_str += ", ";
+		farg_str += to_expression(coffset);
 	}
 	else if (offset)
 	{
 		forward = forward && should_forward(offset);
-		expr += ", ";
-		expr += to_expression(offset);
+		farg_str += ", ";
+		farg_str += to_expression(offset);
 	}
 
 	if (bias)
 	{
 		forward = forward && should_forward(bias);
-		expr += ", ";
-		expr += to_expression(bias);
+		farg_str += ", ";
+		farg_str += to_expression(bias);
 	}
 
 	if (comp)
 	{
 		forward = forward && should_forward(comp);
-		expr += ", ";
-		expr += to_expression(comp);
+		farg_str += ", ";
+		farg_str += to_expression(comp);
 	}
 
 	if (sample)
 	{
-		expr += ", ";
-		expr += to_expression(sample);
+		farg_str += ", ";
+		farg_str += to_expression(sample);
 	}
 
-	expr += ")";
+	*p_forward = forward;
 
-	emit_op(result_type, id, expr, forward);
+	return farg_str;
 }
 
 void CompilerGLSL::emit_glsl_op(uint32_t result_type, uint32_t id, uint32_t eop, const uint32_t *args, uint32_t)

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -4766,7 +4766,7 @@ bool CompilerGLSL::is_non_native_row_major_matrix(uint32_t id)
 	// swaps matrix elements while retaining the original dimensional form of the matrix.
 	const auto type = expression_type(id);
 	if (type.columns != type.vecsize)
-		throw CompilerError("Row-major matrices must be square on this platform.");
+		SPIRV_CROSS_THROW("Row-major matrices must be square on this platform.");
 
 	return true;
 }
@@ -4787,7 +4787,7 @@ bool CompilerGLSL::member_is_non_native_row_major_matrix(const SPIRType &type, u
 	// swaps matrix elements while retaining the original dimensional form of the matrix.
 	const auto mbr_type = get<SPIRType>(type.member_types[index]);
 	if (mbr_type.columns != mbr_type.vecsize)
-		throw CompilerError("Row-major matrices must be square on this platform.");
+		SPIRV_CROSS_THROW("Row-major matrices must be square on this platform.");
 
 	return true;
 }

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -184,7 +184,7 @@ void CompilerGLSL::remap_pls_variables()
 		}
 
 		if (var.storage != StorageClassInput && !input_is_target)
-			throw CompilerError("Can only use in and target variables for PLS inputs.");
+			SPIRV_CROSS_THROW("Can only use in and target variables for PLS inputs.");
 		var.remapped_variable = true;
 	}
 
@@ -192,7 +192,7 @@ void CompilerGLSL::remap_pls_variables()
 	{
 		auto &var = get<SPIRVariable>(output.id);
 		if (var.storage != StorageClassOutput)
-			throw CompilerError("Can only use out variables for PLS outputs.");
+			SPIRV_CROSS_THROW("Can only use out variables for PLS outputs.");
 		var.remapped_variable = true;
 	}
 }
@@ -207,7 +207,7 @@ void CompilerGLSL::find_static_extensions()
 			if (type.basetype == SPIRType::Double)
 			{
 				if (options.es)
-					throw CompilerError("FP64 not supported in ES profile.");
+					SPIRV_CROSS_THROW("FP64 not supported in ES profile.");
 				if (!options.es && options.version < 400)
 					require_extension("GL_ARB_gpu_shader_fp64");
 			}
@@ -215,7 +215,7 @@ void CompilerGLSL::find_static_extensions()
 			if (type.basetype == SPIRType::Int64 || type.basetype == SPIRType::UInt64)
 			{
 				if (options.es)
-					throw CompilerError("64-bit integers not supported in ES profile.");
+					SPIRV_CROSS_THROW("64-bit integers not supported in ES profile.");
 				if (!options.es)
 					require_extension("GL_ARB_gpu_shader_int64");
 			}
@@ -229,7 +229,7 @@ void CompilerGLSL::find_static_extensions()
 		if (!options.es && options.version < 430)
 			require_extension("GL_ARB_compute_shader");
 		if (options.es && options.version < 310)
-			throw CompilerError("At least ESSL 3.10 required for compute shaders.");
+			SPIRV_CROSS_THROW("At least ESSL 3.10 required for compute shaders.");
 		break;
 
 	case ExecutionModelGeometry:
@@ -271,7 +271,7 @@ string CompilerGLSL::compile()
 	do
 	{
 		if (pass_count >= 3)
-			throw CompilerError("Over 3 compilation loops detected. Must be a bug!");
+			SPIRV_CROSS_THROW("Over 3 compilation loops detected. Must be a bug!");
 
 		reset();
 
@@ -561,7 +561,7 @@ const char *CompilerGLSL::format_to_glsl(spv::ImageFormat format)
 {
 	auto check_desktop = [this] {
 		if (options.es)
-			throw CompilerError("Attempting to use image format not supported in ES profile.");
+			SPIRV_CROSS_THROW("Attempting to use image format not supported in ES profile.");
 	};
 
 	switch (format)
@@ -747,7 +747,7 @@ uint32_t CompilerGLSL::type_to_std430_alignment(const SPIRType &type, uint64_t f
 		// Rule 8 implied.
 	}
 
-	throw CompilerError("Did not find suitable std430 rule for type. Bogus decorations?");
+	SPIRV_CROSS_THROW("Did not find suitable std430 rule for type. Bogus decorations?");
 }
 
 uint32_t CompilerGLSL::type_to_std430_array_stride(const SPIRType &type, uint64_t flags)
@@ -978,7 +978,7 @@ void CompilerGLSL::emit_push_constant_block_glsl(const SPIRVariable &var)
 
 #if 0
     if (flags & ((1ull << DecorationBinding) | (1ull << DecorationDescriptorSet)))
-        throw CompilerError("Push constant blocks cannot be compiled to GLSL with Binding or Set syntax. "
+        SPIRV_CROSS_THROW("Push constant blocks cannot be compiled to GLSL with Binding or Set syntax. "
                             "Remap to location with reflection API first or disable these decorations.");
 #endif
 
@@ -1096,7 +1096,7 @@ void CompilerGLSL::emit_uniform(const SPIRVariable &var)
 		if (!options.es && options.version < 420)
 			require_extension("GL_ARB_shader_image_load_store");
 		else if (options.es && options.version < 310)
-			throw CompilerError("At least ESSL 3.10 required for shader image load store.");
+			SPIRV_CROSS_THROW("At least ESSL 3.10 required for shader image load store.");
 	}
 
 	add_resource_name(var.self);
@@ -1182,14 +1182,14 @@ void CompilerGLSL::replace_fragment_output(SPIRVariable &var)
 		// FIXME: This seems like an extremely odd-ball case, so it's probably fine to leave it like this for now.
 		m.alias = "gl_FragData";
 		if (location != 0)
-			throw CompilerError("Arrayed output variable used, but location is not 0. "
-			                    "This is unimplemented in SPIRV-Cross.");
+			SPIRV_CROSS_THROW("Arrayed output variable used, but location is not 0. "
+			                  "This is unimplemented in SPIRV-Cross.");
 
 		if (is_legacy_es())
 			require_extension("GL_EXT_draw_buffers");
 	}
 	else
-		throw CompilerError("Array-of-array output variable used. This cannot be implemented in legacy GLSL.");
+		SPIRV_CROSS_THROW("Array-of-array output variable used. This cannot be implemented in legacy GLSL.");
 
 	var.compat_builtin = true; // We don't want to declare this variable, but use the name as-is.
 }
@@ -1234,13 +1234,13 @@ void CompilerGLSL::emit_pls()
 {
 	auto &execution = get_entry_point();
 	if (execution.model != ExecutionModelFragment)
-		throw CompilerError("Pixel local storage only supported in fragment shaders.");
+		SPIRV_CROSS_THROW("Pixel local storage only supported in fragment shaders.");
 
 	if (!options.es)
-		throw CompilerError("Pixel local storage only supported in OpenGL ES.");
+		SPIRV_CROSS_THROW("Pixel local storage only supported in OpenGL ES.");
 
 	if (options.version < 300)
-		throw CompilerError("Pixel local storage only supported in ESSL 3.0 and above.");
+		SPIRV_CROSS_THROW("Pixel local storage only supported in ESSL 3.0 and above.");
 
 	if (!pls_inputs.empty())
 	{
@@ -1649,7 +1649,7 @@ string CompilerGLSL::constant_op_expression(const SPIRConstantOp &cop)
 	case OpSelect:
 	{
 		if (cop.arguments.size() < 3)
-			throw CompilerError("Not enough arguments to OpSpecConstantOp.");
+			SPIRV_CROSS_THROW("Not enough arguments to OpSpecConstantOp.");
 
 		// This one is pretty annoying. It's triggered from
 		// uint(bool), int(bool) from spec constants.
@@ -1658,7 +1658,7 @@ string CompilerGLSL::constant_op_expression(const SPIRConstantOp &cop)
 		// If we cannot, fail.
 		if (!to_trivial_mix_op(type, op, cop.arguments[2], cop.arguments[1], cop.arguments[0]))
 		{
-			throw CompilerError(
+			SPIRV_CROSS_THROW(
 			    "Cannot implement specialization constant op OpSelect. "
 			    "Need trivial select implementation which can be resolved to a simple cast from boolean.");
 		}
@@ -1667,7 +1667,7 @@ string CompilerGLSL::constant_op_expression(const SPIRConstantOp &cop)
 
 	default:
 		// Some opcodes are unimplemented here, these are currently not possible to test from glslang.
-		throw CompilerError("Unimplemented spec constant op.");
+		SPIRV_CROSS_THROW("Unimplemented spec constant op.");
 	}
 
 	SPIRType::BaseType input_type;
@@ -1690,7 +1690,7 @@ string CompilerGLSL::constant_op_expression(const SPIRConstantOp &cop)
 	if (binary)
 	{
 		if (cop.arguments.size() < 2)
-			throw CompilerError("Not enough arguments to OpSpecConstantOp.");
+			SPIRV_CROSS_THROW("Not enough arguments to OpSpecConstantOp.");
 
 		string cast_op0;
 		string cast_op1;
@@ -1712,7 +1712,7 @@ string CompilerGLSL::constant_op_expression(const SPIRConstantOp &cop)
 	else if (unary)
 	{
 		if (cop.arguments.size() < 1)
-			throw CompilerError("Not enough arguments to OpSpecConstantOp.");
+			SPIRV_CROSS_THROW("Not enough arguments to OpSpecConstantOp.");
 
 		// Auto-bitcast to result type as needed.
 		// Works around various casting scenarios in glslang as there is no OpBitcast for specialization constants.
@@ -1721,7 +1721,7 @@ string CompilerGLSL::constant_op_expression(const SPIRConstantOp &cop)
 	else
 	{
 		if (cop.arguments.size() < 1)
-			throw CompilerError("Not enough arguments to OpSpecConstantOp.");
+			SPIRV_CROSS_THROW("Not enough arguments to OpSpecConstantOp.");
 		return join(op, "(", to_expression(cop.arguments[0]), ")");
 	}
 }
@@ -1937,7 +1937,7 @@ string CompilerGLSL::constant_expression_vector(const SPIRConstant &c, uint32_t 
 		break;
 
 	default:
-		throw CompilerError("Invalid constant expression basetype.");
+		SPIRV_CROSS_THROW("Invalid constant expression basetype.");
 	}
 
 	if (c.vector_size() > 1)
@@ -2204,7 +2204,9 @@ string CompilerGLSL::legacy_tex_op(const std::string &op, const SPIRType &imgtyp
 	else if (op == "textureProjLod")
 		return join("texture", type, is_legacy_es() ? "ProjLodEXT" : "ProjLod");
 	else
-		throw CompilerError(join("Unsupported legacy texture op: ", op));
+	{
+		SPIRV_CROSS_THROW(join("Unsupported legacy texture op: ", op));
+	}
 }
 
 bool CompilerGLSL::to_trivial_mix_op(const SPIRType &type, string &op, uint32_t left, uint32_t right, uint32_t lerp)
@@ -2349,7 +2351,7 @@ string CompilerGLSL::to_combined_image_sampler(uint32_t image_id, uint32_t samp_
 			return to_expression(itr->id);
 		else
 		{
-			throw CompilerError(
+			SPIRV_CROSS_THROW(
 			    "Cannot find mapping for combined sampler parameter, was build_combined_image_samplers() used "
 			    "before compile() was called?");
 		}
@@ -2366,8 +2368,8 @@ string CompilerGLSL::to_combined_image_sampler(uint32_t image_id, uint32_t samp_
 			return to_expression(itr->combined_id);
 		else
 		{
-			throw CompilerError("Cannot find mapping for combined sampler, was build_combined_image_samplers() used "
-			                    "before compile() was called?");
+			SPIRV_CROSS_THROW("Cannot find mapping for combined sampler, was build_combined_image_samplers() used "
+			                  "before compile() was called?");
 		}
 	}
 }
@@ -2390,7 +2392,7 @@ void CompilerGLSL::emit_texture_op(const Instruction &i)
 	uint32_t length = i.length;
 
 	if (i.offset + length > spirv.size())
-		throw CompilerError("Compiler::parse() opcode out of range.");
+		SPIRV_CROSS_THROW("Compiler::parse() opcode out of range.");
 
 	uint32_t result_type = ops[0];
 	uint32_t id = ops[1];
@@ -2669,7 +2671,7 @@ void CompilerGLSL::emit_glsl_op(uint32_t result_type, uint32_t id, uint32_t eop,
 		if ((options.es && options.version >= 300) || (!options.es && options.version >= 130))
 			emit_unary_func_op(result_type, id, args[0], "roundEven");
 		else
-			throw CompilerError("roundEven supported only in ESSL 300 and GLSL 130 and up.");
+			SPIRV_CROSS_THROW("roundEven supported only in ESSL 300 and GLSL 130 and up.");
 		break;
 
 	case GLSLstd450Trunc:
@@ -2955,12 +2957,12 @@ string CompilerGLSL::builtin_to_glsl(BuiltIn builtin)
 		return "gl_PointSize";
 	case BuiltInVertexId:
 		if (options.vulkan_semantics)
-			throw CompilerError(
+			SPIRV_CROSS_THROW(
 			    "Cannot implement gl_VertexID in Vulkan GLSL. This shader was created with GL semantics.");
 		return "gl_VertexID";
 	case BuiltInInstanceId:
 		if (options.vulkan_semantics)
-			throw CompilerError(
+			SPIRV_CROSS_THROW(
 			    "Cannot implement gl_InstanceID in Vulkan GLSL. This shader was created with GL semantics.");
 		return "gl_InstanceID";
 	case BuiltInVertexIndex:
@@ -3023,7 +3025,7 @@ const char *CompilerGLSL::index_to_swizzle(uint32_t index)
 	case 3:
 		return "w";
 	default:
-		throw CompilerError("Swizzle index out of range");
+		SPIRV_CROSS_THROW("Swizzle index out of range");
 	}
 }
 
@@ -3072,7 +3074,7 @@ string CompilerGLSL::access_chain(uint32_t base, const uint32_t *indices, uint32
 				index = get<SPIRConstant>(index).scalar();
 
 			if (index >= type->member_types.size())
-				throw CompilerError("Member index is out of bounds!");
+				SPIRV_CROSS_THROW("Member index is out of bounds!");
 
 			BuiltIn builtin;
 			if (is_member_builtin(*type, index, &builtin))
@@ -3146,7 +3148,7 @@ string CompilerGLSL::access_chain(uint32_t base, const uint32_t *indices, uint32
 			temp.vecsize = 1;
 		}
 		else
-			throw CompilerError("Cannot subdivide a scalar value!");
+			SPIRV_CROSS_THROW("Cannot subdivide a scalar value!");
 	}
 
 	return expr;
@@ -3620,7 +3622,7 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 		length -= 2;
 
 		if (!length)
-			throw CompilerError("Invalid input to OpCompositeConstruct.");
+			SPIRV_CROSS_THROW("Invalid input to OpCompositeConstruct.");
 
 		bool forward = true;
 		for (uint32_t i = 0; i < length; i++)
@@ -4197,7 +4199,7 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 			break;
 		}
 		default:
-			throw CompilerError("Illegal argument to OpQuantizeToF16.");
+			SPIRV_CROSS_THROW("Illegal argument to OpQuantizeToF16.");
 		}
 
 		emit_op(result_type, id, op, should_forward(arg));
@@ -4424,7 +4426,7 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 			BFOP(textureQueryLOD);
 		}
 		else if (options.es)
-			throw CompilerError("textureQueryLod not supported in ES profile.");
+			SPIRV_CROSS_THROW("textureQueryLod not supported in ES profile.");
 		else
 			BFOP(textureQueryLod);
 		break;
@@ -4435,7 +4437,7 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 		if (!options.es && options.version < 430)
 			require_extension("GL_ARB_texture_query_levels");
 		if (options.es)
-			throw CompilerError("textureQueryLevels not supported in ES profile.");
+			SPIRV_CROSS_THROW("textureQueryLevels not supported in ES profile.");
 		UFOP(textureQueryLevels);
 		break;
 	}
@@ -4444,7 +4446,7 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 	{
 		auto *var = maybe_get_backing_variable(ops[2]);
 		if (!var)
-			throw CompilerError(
+			SPIRV_CROSS_THROW(
 			    "Bug. OpImageQuerySamples must have a backing variable so we know if the image is sampled or not.");
 
 		auto &type = get<SPIRType>(var->basetype);
@@ -4495,7 +4497,7 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 		if (var && var->remapped_variable) // Remapped input, just read as-is without any op-code
 		{
 			if (type.image.ms)
-				throw CompilerError("Trying to remap multisampled image to variable, this is not possible.");
+				SPIRV_CROSS_THROW("Trying to remap multisampled image to variable, this is not possible.");
 
 			auto itr =
 			    find_if(begin(pls_inputs), end(pls_inputs), [var](const PlsRemap &pls) { return pls.id == var->self; });
@@ -4505,7 +4507,7 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 				// For non-PLS inputs, we rely on subpass type remapping information to get it right
 				// since ImageRead always returns 4-component vectors and the backing type is opaque.
 				if (!var->remapped_components)
-					throw CompilerError("subpassInput was remapped, but remap_components is not set correctly.");
+					SPIRV_CROSS_THROW("subpassInput was remapped, but remap_components is not set correctly.");
 				imgexpr = remap_swizzle(result_type, var->remapped_components, ops[2]);
 			}
 			else
@@ -4526,7 +4528,7 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 				{
 					uint32_t operands = ops[4];
 					if (operands != ImageOperandsSampleMask || length != 6)
-						throw CompilerError(
+						SPIRV_CROSS_THROW(
 						    "Multisampled image used in OpImageRead, but unexpected operand mask was used.");
 
 					uint32_t samples = ops[5];
@@ -4541,7 +4543,7 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 				{
 					uint32_t operands = ops[4];
 					if (operands != ImageOperandsSampleMask || length != 6)
-						throw CompilerError(
+						SPIRV_CROSS_THROW(
 						    "Multisampled image used in OpImageRead, but unexpected operand mask was used.");
 
 					uint32_t samples = ops[5];
@@ -4563,8 +4565,7 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 			{
 				uint32_t operands = ops[4];
 				if (operands != ImageOperandsSampleMask || length != 6)
-					throw CompilerError(
-					    "Multisampled image used in OpImageRead, but unexpected operand mask was used.");
+					SPIRV_CROSS_THROW("Multisampled image used in OpImageRead, but unexpected operand mask was used.");
 
 				uint32_t samples = ops[5];
 				imgexpr = join("imageLoad(", to_expression(ops[2]), ", ", to_expression(ops[3]), ", ",
@@ -4624,7 +4625,7 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 		{
 			uint32_t operands = ops[3];
 			if (operands != ImageOperandsSampleMask || length != 5)
-				throw CompilerError("Multisampled image used in OpImageWrite, but unexpected operand mask was used.");
+				SPIRV_CROSS_THROW("Multisampled image used in OpImageWrite, but unexpected operand mask was used.");
 			uint32_t samples = ops[4];
 			statement("imageStore(", to_expression(ops[0]), ", ", to_expression(ops[1]), ", ", to_expression(samples),
 			          ", ", to_expression(ops[2]), ");");
@@ -4650,7 +4651,7 @@ void CompilerGLSL::emit_instruction(const Instruction &instruction)
 			emit_op(result_type, id, join("imageSize(", to_expression(ops[2]), ")"), true);
 		}
 		else
-			throw CompilerError("Invalid type for OpImageQuerySize.");
+			SPIRV_CROSS_THROW("Invalid type for OpImageQuerySize.");
 		break;
 	}
 
@@ -4951,7 +4952,7 @@ uint32_t CompilerGLSL::to_array_size_literal(const SPIRType &type, uint32_t inde
 	assert(type.array.size() == type.array_size_literal.size());
 
 	if (!type.array_size_literal[index])
-		throw CompilerError("The array size is not a literal, but a specialization constant or spec constant op.");
+		SPIRV_CROSS_THROW("The array size is not a literal, but a specialization constant or spec constant op.");
 
 	return type.array[index];
 }
@@ -5048,7 +5049,7 @@ string CompilerGLSL::image_type_glsl(const SPIRType &type)
 		res += "2D";
 		break;
 	default:
-		throw CompilerError("Only 1D, 2D, 3D, Buffer, InputTarget and Cube textures supported.");
+		SPIRV_CROSS_THROW("Only 1D, 2D, 3D, Buffer, InputTarget and Cube textures supported.");
 	}
 
 	if (type.image.ms)
@@ -5642,7 +5643,7 @@ bool CompilerGLSL::attempt_emit_loop_header(SPIRBlock &block, SPIRBlock::Method 
 				break;
 
 			default:
-				throw CompilerError("For/while loop detected, but need while/for loop semantics.");
+				SPIRV_CROSS_THROW("For/while loop detected, but need while/for loop semantics.");
 			}
 
 			begin_scope();
@@ -5689,7 +5690,7 @@ bool CompilerGLSL::attempt_emit_loop_header(SPIRBlock &block, SPIRBlock::Method 
 				break;
 
 			default:
-				throw CompilerError("For/while loop detected, but need while/for loop semantics.");
+				SPIRV_CROSS_THROW("For/while loop detected, but need while/for loop semantics.");
 			}
 
 			begin_scope();
@@ -5837,7 +5838,7 @@ void CompilerGLSL::emit_block_chain(SPIRBlock &block)
 			statement("default:");
 			begin_scope();
 			if (is_break(block.default_block))
-				throw CompilerError("Cannot break; out of a switch statement and out of a loop at the same time ...");
+				SPIRV_CROSS_THROW("Cannot break; out of a switch statement and out of a loop at the same time ...");
 			branch(block.self, block.default_block);
 			end_scope();
 		}
@@ -5878,7 +5879,7 @@ void CompilerGLSL::emit_block_chain(SPIRBlock &block)
 		break;
 
 	default:
-		throw CompilerError("Unimplemented block terminator.");
+		SPIRV_CROSS_THROW("Unimplemented block terminator.");
 	}
 
 	if (block.next_block && emit_next_block)
@@ -5924,7 +5925,7 @@ void CompilerGLSL::begin_scope()
 void CompilerGLSL::end_scope()
 {
 	if (!indent)
-		throw CompilerError("Popping empty indent stack.");
+		SPIRV_CROSS_THROW("Popping empty indent stack.");
 	indent--;
 	statement("}");
 }
@@ -5932,7 +5933,7 @@ void CompilerGLSL::end_scope()
 void CompilerGLSL::end_scope_decl()
 {
 	if (!indent)
-		throw CompilerError("Popping empty indent stack.");
+		SPIRV_CROSS_THROW("Popping empty indent stack.");
 	indent--;
 	statement("};");
 }
@@ -5940,7 +5941,7 @@ void CompilerGLSL::end_scope_decl()
 void CompilerGLSL::end_scope_decl(const string &decl)
 {
 	if (!indent)
-		throw CompilerError("Popping empty indent stack.");
+		SPIRV_CROSS_THROW("Popping empty indent stack.");
 	indent--;
 	statement("} ", decl, ";");
 }
@@ -5960,10 +5961,10 @@ void CompilerGLSL::check_function_call_constraints(const uint32_t *args, uint32_
 		auto &type = get<SPIRType>(var->basetype);
 		if (type.basetype == SPIRType::Image && type.image.dim == DimSubpassData)
 		{
-			throw CompilerError("Tried passing a remapped subpassInput variable to a function. "
-			                    "This will not work correctly because type-remapping information is lost. "
-			                    "To workaround, please consider not passing the subpass input as a function parameter, "
-			                    "or use in/out variables instead which do not need type remapping information.");
+			SPIRV_CROSS_THROW("Tried passing a remapped subpassInput variable to a function. "
+			                  "This will not work correctly because type-remapping information is lost. "
+			                  "To workaround, please consider not passing the subpass input as a function parameter, "
+			                  "or use in/out variables instead which do not need type remapping information.");
 		}
 	}
 }

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -2953,6 +2953,8 @@ string CompilerGLSL::builtin_to_glsl(BuiltIn builtin)
 		return "gl_Position";
 	case BuiltInPointSize:
 		return "gl_PointSize";
+	case BuiltInClipDistance:
+		return "gl_ClipDistance";
 	case BuiltInVertexId:
 		if (options.vulkan_semantics)
 			throw CompilerError(
@@ -3006,7 +3008,7 @@ string CompilerGLSL::builtin_to_glsl(BuiltIn builtin)
 	case BuiltInLocalInvocationIndex:
 		return "gl_LocalInvocationIndex";
 	default:
-		return "gl_???";
+		return join("gl_BuiltIn_", convert_to_string(builtin));
 	}
 }
 

--- a/spirv_glsl.cpp
+++ b/spirv_glsl.cpp
@@ -2558,9 +2558,8 @@ void CompilerGLSL::emit_texture_op(const Instruction &i)
 
 // Returns the function name for a texture sampling function for the specified image and sampling characteristics.
 // For some subclasses, the function is a method on the specified image.
-string CompilerGLSL::to_function_name(uint32_t, const SPIRType &imgtype, bool is_fetch, bool is_gather,
-                                      bool is_proj, bool has_array_offsets, bool has_offset, bool has_grad,
-                                      bool has_lod, bool)
+string CompilerGLSL::to_function_name(uint32_t, const SPIRType &imgtype, bool is_fetch, bool is_gather, bool is_proj,
+                                      bool has_array_offsets, bool has_offset, bool has_grad, bool has_lod, bool)
 {
 	string fname;
 
@@ -2589,10 +2588,10 @@ string CompilerGLSL::to_function_name(uint32_t, const SPIRType &imgtype, bool is
 }
 
 // Returns the function args for a texture sampling function for the specified image and sampling characteristics.
-string CompilerGLSL::to_function_args(uint32_t img, const SPIRType &, bool, bool,
-                                      bool, uint32_t coord, uint32_t coord_components, uint32_t dref,
-                                      uint32_t grad_x, uint32_t grad_y, uint32_t lod, uint32_t coffset, uint32_t offset,
-                                      uint32_t bias, uint32_t comp, uint32_t sample, bool *p_forward)
+string CompilerGLSL::to_function_args(uint32_t img, const SPIRType &, bool, bool, bool, uint32_t coord,
+                                      uint32_t coord_components, uint32_t dref, uint32_t grad_x, uint32_t grad_y,
+                                      uint32_t lod, uint32_t coffset, uint32_t offset, uint32_t bias, uint32_t comp,
+                                      uint32_t sample, bool *p_forward)
 {
 	string farg_str = to_expression(img);
 
@@ -2716,7 +2715,7 @@ string CompilerGLSL::to_function_args(uint32_t img, const SPIRType &, bool, bool
 // functions (eg. MSL includes saturate()).
 string CompilerGLSL::clean_func_name(string func_name)
 {
-    return func_name;
+	return func_name;
 }
 
 void CompilerGLSL::emit_glsl_op(uint32_t result_type, uint32_t id, uint32_t eop, const uint32_t *args, uint32_t)

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -160,6 +160,14 @@ protected:
 	virtual void emit_fixup();
 	virtual std::string variable_decl(const SPIRType &type, const std::string &name);
 	virtual std::string to_func_call_arg(uint32_t id);
+	virtual std::string to_function_name(uint32_t img, const SPIRType &imgtype, bool is_fetch, bool is_gather,
+	                                     bool is_proj, bool has_array_offsets, bool has_offset, bool has_grad,
+	                                     bool has_lod, bool has_dref);
+	virtual std::string to_function_args(uint32_t img, const SPIRType &imgtype, bool is_fetch, bool is_gather,
+	                                     bool is_proj, uint32_t coord, uint32_t coord_components, uint32_t dref,
+	                                     uint32_t grad_x, uint32_t grad_y, uint32_t lod, uint32_t coffset,
+	                                     uint32_t offset, uint32_t bias, uint32_t comp, uint32_t sample,
+	                                     bool *p_forward);
 
 	std::unique_ptr<std::ostringstream> buffer;
 

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -390,8 +390,8 @@ protected:
 	void find_static_extensions();
 
 	std::string emit_for_loop_initializers(const SPIRBlock &block);
-
 	bool optimize_read_modify_write(const std::string &lhs, const std::string &rhs);
+	void fixup_image_load_store_access();
 };
 }
 

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -168,7 +168,7 @@ protected:
 	                                     uint32_t grad_x, uint32_t grad_y, uint32_t lod, uint32_t coffset,
 	                                     uint32_t offset, uint32_t bias, uint32_t comp, uint32_t sample,
 	                                     bool *p_forward);
-    virtual std::string clean_func_name(std::string func_name);
+	virtual std::string clean_func_name(std::string func_name);
 
 	std::unique_ptr<std::ostringstream> buffer;
 

--- a/spirv_glsl.hpp
+++ b/spirv_glsl.hpp
@@ -168,6 +168,7 @@ protected:
 	                                     uint32_t grad_x, uint32_t grad_y, uint32_t lod, uint32_t coffset,
 	                                     uint32_t offset, uint32_t bias, uint32_t comp, uint32_t sample,
 	                                     bool *p_forward);
+    virtual std::string clean_func_name(std::string func_name);
 
 	std::unique_ptr<std::ostringstream> buffer;
 

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -1390,6 +1390,7 @@ string CompilerMSL::clean_func_name(string func_name)
 }
 
 void CompilerMSL::set_func_name(std::string func_name) {
+    if (func_name.find("main") == std::string::npos) func_name += "_main";
     _clean_msl_main_func_name = func_name;
 }
 

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -816,7 +816,7 @@ void CompilerMSL::emit_function_prototype(SPIRFunction &func, bool is_decl)
 			      var_type.storage == StorageClassPushConstant));
 		}
 
-		decl += (is_uniform_struct ? "constant " : "thread ");
+               decl += (is_uniform_struct ? "constant " : "thread ");
 		decl += argument_decl(arg);
 
 		// Manufacture automatic sampler arg for SampledImage texture
@@ -1611,9 +1611,12 @@ string CompilerMSL::argument_decl(const SPIRFunction::Parameter &arg)
 {
 	auto &type = expression_type(arg.id);
 	bool constref = !type.pointer || arg.write_count == 0;
+    
+    // TODO: Check if this arg is an uniform pointer
+    bool pointer = type.storage == StorageClassUniformConstant;
 
 	auto &var = get<SPIRVariable>(arg.id);
-	return join(constref ? "const " : "", type_to_glsl(type), "& ", to_name(var.self), type_to_array_glsl(type));
+    return join(constref ? "const " : "", type_to_glsl(type), pointer ? " " : "& ", to_name(var.self), type_to_array_glsl(type));
 }
 
 // If we're currently in the entry point function, and the object

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -520,6 +520,13 @@ uint32_t CompilerMSL::add_interface_struct(StorageClass storage, uint32_t vtx_bi
 	// Sort the members of the interface structure by their offsets
 	MemberSorter memberSorter(ib_type, meta[ib_type.self], MemberSorter::Offset);
 	memberSorter.sort();
+    
+    // Sort input or output variables alphabetical
+    if ((execution.model == ExecutionModelFragment && storage == StorageClassInput) ||
+        (execution.model == ExecutionModelVertex && storage == StorageClassOutput)) {
+        MemberSorter memberSorter(ib_type, meta[ib_type.self], MemberSorter::Alphabetical);
+        memberSorter.sort();
+    }
 
 	return ib_var_id;
 }
@@ -2034,6 +2041,8 @@ bool MemberSorter::operator()(uint32_t mbr_idx1, uint32_t mbr_idx2)
 			return mbr_meta1.location < mbr_meta2.location;
 		case Offset:
 			return mbr_meta1.offset < mbr_meta2.offset;
+        case Alphabetical:
+            return mbr_meta1.alias > mbr_meta2.alias;
 		default:
 			return false;
 		}

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -289,7 +289,7 @@ void CompilerMSL::add_interface_structs()
 	}
     
 	stage_out_var_id = add_interface_struct(StorageClassOutput);
-    stage_uniforms_var_id = add_interface_struct(StorageClassUniformConstant); // TODO: use StorageClassUniform
+    stage_uniforms_var_id = add_interface_struct(StorageClassUniformConstant);
 }
 
 // Iterate through the variables and populates each input vertex attribute variable
@@ -480,7 +480,9 @@ uint32_t CompilerMSL::add_interface_struct(StorageClass storage, uint32_t vtx_bi
 				i++;
 			}
 		}
-		else
+        else if (type.basetype == SPIRType::Boolean || type.basetype == SPIRType::Char || type.basetype == SPIRType::Int ||
+                 type.basetype == SPIRType::UInt || type.basetype == SPIRType::Int64 || type.basetype == SPIRType::UInt64 ||
+                 type.basetype == SPIRType::Float || type.basetype == SPIRType::Double || type.basetype == SPIRType::Boolean)
 		{
 			// If needed, add a padding member to the struct to align to the next member's offset.
 			struct_size = pad_to_offset(ib_type, is_indxd_vtx_input, var_dec.offset, uint32_t(struct_size));

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -1176,9 +1176,10 @@ void CompilerMSL::emit_fixup()
 	{
 		if (options.vertex.fixup_clipspace)
 		{
-			const char *suffix = backend.float_literal_suffix ? "f" : "";
+			/*const char *suffix = backend.float_literal_suffix ? "f" : "";
 			statement(qual_pos_var_name, ".z = 2.0", suffix, " * ", qual_pos_var_name, ".z - ", qual_pos_var_name,
-			          ".w;", "    // Adjust clip-space for Metal");
+			          ".w;", "    // Adjust clip-space for Metal");*/
+            statement(qual_pos_var_name, ".z = (", qual_pos_var_name, ".z + ", qual_pos_var_name, ".w) * 0.5;       // Adjust clip-space for Metal");
 		}
 
 		if (msl_config.flip_vert_y)

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -1652,10 +1652,15 @@ string CompilerMSL::to_qualified_member_name(const SPIRType &type, uint32_t inde
 // if the first chars are _ and a digit, which indicate a transient name.
 string CompilerMSL::ensure_valid_name(string name, string pfx)
 {
-	if (name.size() >= 2 && name[0] == '_' && isdigit(name[1]))
+   if (name.size() >= 2 && name[0] == '_' && isdigit(name[1])) {
 		return join(pfx, name);
-	else
+    }
+    else if (std::find(reserved_names.begin(), reserved_names.end(), name) != reserved_names.end()) {
+        return join(pfx, name);
+    }
+    else {
 		return name;
+    }
 }
 
 // Returns an MSL string describing  the SPIR-V type

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -1385,8 +1385,12 @@ string CompilerMSL::func_type_decl(SPIRType &type)
 // Ensures the function name is not "main", which is illegal in MSL
 string CompilerMSL::clean_func_name(string func_name)
 {
-	static std::string _clean_msl_main_func_name = "mmain";
+	if (_clean_msl_main_func_name.empty()) _clean_msl_main_func_name = "mmain";
 	return (func_name == "main") ? _clean_msl_main_func_name : func_name;
+}
+
+void CompilerMSL::set_func_name(std::string func_name) {
+    _clean_msl_main_func_name = func_name;
 }
 
 // Returns a string containing a comma-delimited list of args for the entry point function

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -494,7 +494,9 @@ uint32_t CompilerMSL::add_interface_struct(StorageClass storage, uint32_t vtx_bi
 
 			// Copy the variable location from the original variable to the member
 			auto &dec = meta[p_var->self].decoration;
-			set_member_decoration(ib_type.self, ib_mbr_idx, DecorationLocation, dec.location);
+            if (is_decoration_set(p_var->self, DecorationLocation)) {
+                set_member_decoration(ib_type.self, ib_mbr_idx, DecorationLocation, dec.location);
+            }
 
 			// Mark the member as builtin if needed
 			if (is_builtin_variable(*p_var))

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -1523,6 +1523,7 @@ uint32_t CompilerMSL::get_metal_resource_index(SPIRVariable &var, SPIRType::Base
 	switch (basetype)
 	{
 	case SPIRType::Struct:
+        if (execution.model == ExecutionModelVertex && next_metal_resource_index.msl_buffer == 0) next_metal_resource_index.msl_buffer = 1;
 		return next_metal_resource_index.msl_buffer++;
 	case SPIRType::Image:
 		return next_metal_resource_index.msl_texture++;

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -19,6 +19,8 @@
 #include <algorithm>
 #include <numeric>
 
+#include <iostream>
+
 using namespace spv;
 using namespace spirv_cross;
 using namespace std;
@@ -285,8 +287,9 @@ void CompilerMSL::add_interface_structs()
 		if (var_id)
 			stage_in_var_ids.push_back(var_id);
 	}
-
+    
 	stage_out_var_id = add_interface_struct(StorageClassOutput);
+    stage_uniforms_var_id = add_interface_struct(StorageClassUniformConstant); // TODO: use StorageClassUniform
 }
 
 // Iterate through the variables and populates each input vertex attribute variable
@@ -409,6 +412,10 @@ uint32_t CompilerMSL::add_interface_struct(StorageClass storage, uint32_t vtx_bi
 				blk.return_value = ib_var_id;
 		}
 	}
+    
+    if (storage == StorageClassUniformConstant) {
+        ib_var_ref = stage_uniform_var_name;
+    }
 
 	set_name(ib_type_id, get_entry_point_name() + "_" + ib_var_ref);
 	set_name(ib_var_id, ib_var_ref);
@@ -573,6 +580,9 @@ void CompilerMSL::emit_resources()
 	emit_interface_block(stage_out_var_id);
 
 	// TODO: Consolidate and output loose uniforms into an input struct
+    
+    emit_interface_block(stage_uniforms_var_id);
+    
 }
 
 // Override for MSL-specific syntax instructions

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -699,9 +699,8 @@ void CompilerMSL::emit_function_prototype(SPIRFunction &func, bool is_decl)
 }
 
 // Returns the texture sampling function string for the specified image and sampling characteristics.
-string CompilerMSL::to_function_name(uint32_t img, const SPIRType &imgtype, bool is_fetch, bool is_gather, bool is_proj,
-                                     bool has_array_offsets, bool has_offset, bool has_grad, bool has_lod,
-                                     bool has_dref)
+string CompilerMSL::to_function_name(uint32_t img, const SPIRType &, bool is_fetch, bool is_gather,
+                                     bool, bool, bool, bool, bool, bool has_dref)
 {
 	// Texture reference
 	string fname = to_expression(img) + ".";
@@ -721,10 +720,10 @@ string CompilerMSL::to_function_name(uint32_t img, const SPIRType &imgtype, bool
 }
 
 // Returns the function args for a texture sampling function for the specified image and sampling characteristics.
-string CompilerMSL::to_function_args(uint32_t img, const SPIRType &imgtype, bool is_fetch, bool is_gather, bool is_proj,
-                                     uint32_t coord, uint32_t coord_components, uint32_t dref, uint32_t grad_x,
-                                     uint32_t grad_y, uint32_t lod, uint32_t coffset, uint32_t offset, uint32_t bias,
-                                     uint32_t comp, uint32_t sample, bool *p_forward)
+string CompilerMSL::to_function_args(uint32_t img, const SPIRType &imgtype, bool is_fetch, bool, bool is_proj,
+                                     uint32_t coord, uint32_t, uint32_t dref, uint32_t grad_x, uint32_t grad_y,
+                                     uint32_t lod, uint32_t coffset, uint32_t offset, uint32_t bias, uint32_t comp,
+                                     uint32_t, bool *p_forward)
 {
 	string farg_str = to_sampler_expression(img);
 

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -1995,7 +1995,7 @@ size_t CompilerMSL::get_declared_type_size(uint32_t type_id, uint64_t dec_mask) 
 }
 
 // If the opcode requires a bespoke custom function be output, remember it.
-bool CompilerMSL::CustomFunctionHandler::handle(Op opcode, const uint32_t *args, uint32_t length)
+bool CompilerMSL::CustomFunctionHandler::handle(Op opcode, const uint32_t * /*args*/, uint32_t /*length*/)
 {
 	switch (opcode)
 	{

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -27,6 +27,15 @@ CompilerMSL::CompilerMSL(vector<uint32_t> spirv_)
     : CompilerGLSL(move(spirv_))
 {
 	options.vertex.fixup_clipspace = false;
+
+    populate_func_name_overrides();
+}
+
+// Populate the collection of function names that need to be overridden
+void CompilerMSL::populate_func_name_overrides()
+{
+    func_name_overrides["main"] = "main0";
+    func_name_overrides["saturate"] = "saturate0";
 }
 
 string CompilerMSL::compile(MSLConfiguration &msl_cfg, vector<MSLVertexAttr> *p_vtx_attrs,
@@ -1203,8 +1212,8 @@ string CompilerMSL::func_type_decl(SPIRType &type)
 // Ensures the function name is not "main", which is illegal in MSL
 string CompilerMSL::clean_func_name(string func_name)
 {
-	static std::string _clean_msl_main_func_name = "mmain";
-	return (func_name == "main") ? _clean_msl_main_func_name : func_name;
+    auto iter = func_name_overrides.find(func_name);
+    return (iter != func_name_overrides.end()) ? iter->second : func_name;
 }
 
 // Returns a string containing a comma-delimited list of args for the entry point function

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -70,7 +70,7 @@ string CompilerMSL::compile(MSLConfiguration &msl_cfg, vector<MSLVertexAttr> *p_
 	do
 	{
 		if (pass_count >= 3)
-			throw CompilerError("Over 3 compilation loops detected. Must be a bug!");
+			SPIRV_CROSS_THROW("Over 3 compilation loops detected. Must be a bug!");
 
 		reset();
 
@@ -688,7 +688,7 @@ void CompilerMSL::emit_instruction(const Instruction &instruction)
 			}
 		}
 		else
-			throw CompilerError("Invalid type for OpImageQuerySize.");
+			SPIRV_CROSS_THROW("Invalid type for OpImageQuerySize.");
 		break;
 	}
 
@@ -819,7 +819,7 @@ void CompilerMSL::emit_texture_op(const Instruction &i)
 	uint32_t length = i.length;
 
 	if (i.offset + length > spirv.size())
-		throw CompilerError("Compiler::compile() opcode out of range.");
+		SPIRV_CROSS_THROW("Compiler::compile() opcode out of range.");
 
 	uint32_t result_type = ops[0];
 	uint32_t id = ops[1];
@@ -1938,7 +1938,7 @@ size_t CompilerMSL::get_declared_type_size(const SPIRType &type, uint64_t dec_ma
 	case SPIRType::Image:
 	case SPIRType::SampledImage:
 	case SPIRType::Sampler:
-		throw CompilerError("Querying size of object with opaque size.");
+		SPIRV_CROSS_THROW("Querying size of object with opaque size.");
 	default:
 		break;
 	}
@@ -1972,7 +1972,7 @@ size_t CompilerMSL::get_declared_type_size(const SPIRType &type, uint64_t dec_ma
 			return dec.array_stride * to_array_size_literal(type, uint32_t(type.array.size()) - 1);
 		else
 		{
-			throw CompilerError("Type does not have ArrayStride set.");
+			SPIRV_CROSS_THROW("Type does not have ArrayStride set.");
 		}
 	}
 }

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -32,8 +32,7 @@ CompilerMSL::CompilerMSL(vector<uint32_t> spirv_)
 string CompilerMSL::compile(MSLConfiguration &msl_cfg, vector<MSLVertexAttr> *p_vtx_attrs,
                             std::vector<MSLResourceBinding> *p_res_bindings)
 {
-	pad_type_ids_by_pad_len.clear();
-
+	// Remember the input parameters
 	msl_config = msl_cfg;
 
 	vtx_attrs_by_location.clear();
@@ -43,21 +42,23 @@ string CompilerMSL::compile(MSLConfiguration &msl_cfg, vector<MSLVertexAttr> *p_
 
 	resource_bindings.clear();
 	if (p_res_bindings)
-	{
-		resource_bindings.reserve(p_res_bindings->size());
 		for (auto &rb : *p_res_bindings)
 			resource_bindings.push_back(&rb);
-	}
 
+	// Establish the need to output any custom functions
 	set_enabled_interface_variables(get_active_interface_variables());
-
 	register_custom_functions();
-	extract_builtins();
+
+	// Create structs to hold input and output variables
+	qual_pos_var_name = "";
+	stage_in_var_id = add_interface_block(StorageClassInput);
+	stage_out_var_id = add_interface_block(StorageClassOutput);
+
+	// Convert the use of global variables to recursively-passed function parameters
 	localize_global_variables();
-	add_interface_structs();
 	extract_global_variables_from_functions();
 
-	// Do not deal with ES-isms like precision, older extensions and such.
+	// Do not deal with GLES-isms like precision, older extensions and such.
 	options.es = false;
 	options.version = 120;
 	backend.float_literal_suffix = false;
@@ -108,53 +109,6 @@ void CompilerMSL::register_custom_functions()
 	traverse_all_reachable_opcodes(get<SPIRFunction>(entry_point), handler);
 }
 
-// Adds any builtins used by this shader to the builtin_vars collection
-void CompilerMSL::extract_builtins()
-{
-	builtin_vars.clear();
-
-	for (auto &id : ids)
-	{
-		if (id.get_type() == TypeVariable)
-		{
-			auto &var = id.get<SPIRVariable>();
-			auto &dec = meta[var.self].decoration;
-
-			if (dec.builtin)
-				builtin_vars[dec.builtin_type] = var.self;
-		}
-	}
-
-	auto &execution = get_entry_point();
-	if (execution.model == ExecutionModelVertex)
-	{
-		if (!(builtin_vars[BuiltInVertexIndex] || builtin_vars[BuiltInVertexId]))
-			add_builtin(BuiltInVertexIndex);
-
-		if (!(builtin_vars[BuiltInInstanceIndex] || builtin_vars[BuiltInInstanceId]))
-			add_builtin(BuiltInInstanceIndex);
-	}
-}
-
-// Adds an appropriate built-in variable for the specified builtin type.
-void CompilerMSL::add_builtin(BuiltIn builtin_type)
-{
-
-	// Add a new typed variable for this interface structure.
-	uint32_t next_id = increase_bound_by(2);
-	uint32_t ib_type_id = next_id++;
-	auto &ib_type = set<SPIRType>(ib_type_id);
-	ib_type.basetype = SPIRType::UInt;
-	ib_type.storage = StorageClassInput;
-
-	uint32_t ib_var_id = next_id++;
-	set<SPIRVariable>(ib_var_id, ib_type_id, StorageClassInput, 0);
-	set_decoration(ib_var_id, DecorationBuiltIn, builtin_type);
-	set_name(ib_var_id, builtin_to_glsl(builtin_type));
-
-	builtin_vars[builtin_type] = ib_var_id;
-}
-
 // Move the Private global variables to the entry function.
 // Non-constant variables cannot have global scope in Metal.
 void CompilerMSL::localize_global_variables()
@@ -171,9 +125,7 @@ void CompilerMSL::localize_global_variables()
 			iter = global_variables.erase(iter);
 		}
 		else
-		{
 			iter++;
-		}
 	}
 }
 
@@ -271,96 +223,31 @@ void CompilerMSL::extract_global_variables_from_function(uint32_t func_id, std::
 	}
 }
 
-// Adds any interface structure variables needed by this shader
-void CompilerMSL::add_interface_structs()
+// If a vertex attribute exists at the location, it is marked as being used by this shader
+void CompilerMSL::mark_location_as_used_by_shader(uint32_t location, StorageClass storage)
 {
+	MSLVertexAttr *p_va;
 	auto &execution = get_entry_point();
-
-	stage_in_var_ids.clear();
-	qual_pos_var_name = "";
-
-	uint32_t var_id;
-	if (execution.model == ExecutionModelVertex && !vtx_attrs_by_location.empty())
-	{
-		std::unordered_set<uint32_t> vtx_bindings;
-		bind_vertex_attributes(vtx_bindings);
-		for (uint32_t vb : vtx_bindings)
-		{
-			var_id = add_interface_struct(StorageClassInput, vb);
-			if (var_id)
-				stage_in_var_ids.push_back(var_id);
-		}
-	}
-	else
-	{
-		var_id = add_interface_struct(StorageClassInput);
-		if (var_id)
-			stage_in_var_ids.push_back(var_id);
-	}
-
-	stage_out_var_id = add_interface_struct(StorageClassOutput);
+	if ((execution.model == ExecutionModelVertex) && (storage == StorageClassInput) &&
+	    (p_va = vtx_attrs_by_location[location]))
+		p_va->used_by_shader = true;
 }
 
-// Iterate through the variables and populates each input vertex attribute variable
-// from the binding info provided during compiler construction, matching by location.
-void CompilerMSL::bind_vertex_attributes(std::unordered_set<uint32_t> &bindings)
-{
-	auto &execution = get_entry_point();
-
-	if (execution.model == ExecutionModelVertex)
-	{
-		for (auto &id : ids)
-		{
-			if (id.get_type() == TypeVariable)
-			{
-				auto &var = id.get<SPIRVariable>();
-				auto &type = get<SPIRType>(var.basetype);
-
-				if (var.storage == StorageClassInput && interface_variable_exists_in_entry_point(var.self) &&
-				    !is_hidden_variable(var) && type.pointer)
-				{
-					auto &dec = meta[var.self].decoration;
-					MSLVertexAttr *p_va = vtx_attrs_by_location[dec.location];
-					if (p_va)
-					{
-						dec.binding = p_va->msl_buffer;
-						dec.offset = p_va->msl_offset;
-						dec.array_stride = p_va->msl_stride;
-						dec.per_instance = p_va->per_instance;
-
-						// Mark the vertex attributes that were used.
-						p_va->used_by_shader = true;
-						bindings.insert(p_va->msl_buffer);
-					}
-				}
-			}
-		}
-	}
-}
-
-// Add an interface structure for the type of storage. For vertex inputs, each
-// binding must have its own structure, and a structure is created for vtx_binding.
-// For non-vertex input, and all outputs, the vtx_binding argument is ignored.
+// Add an interface structure for the type of storage, which is either StorageClassInput or StorageClassOutput.
 // Returns the ID of the newly added variable, or zero if no variable was added.
-uint32_t CompilerMSL::add_interface_struct(StorageClass storage, uint32_t vtx_binding)
+uint32_t CompilerMSL::add_interface_block(StorageClass storage)
 {
-	auto &execution = get_entry_point();
-	bool incl_builtins = (storage == StorageClassOutput);
-	bool match_binding = (execution.model == ExecutionModelVertex) && (storage == StorageClassInput);
-
 	// Accumulate the variables that should appear in the interface struct
 	vector<SPIRVariable *> vars;
+	bool incl_builtins = (storage == StorageClassOutput);
 	for (auto &id : ids)
 	{
 		if (id.get_type() == TypeVariable)
 		{
 			auto &var = id.get<SPIRVariable>();
 			auto &type = get<SPIRType>(var.basetype);
-			auto &dec = meta[var.self].decoration;
-
 			if (var.storage == storage && interface_variable_exists_in_entry_point(var.self) &&
-			    !is_hidden_variable(var, incl_builtins) && (!match_binding || (vtx_binding == dec.binding)) &&
-			    type.pointer)
+			    !is_hidden_variable(var, incl_builtins) && type.pointer)
 			{
 				vars.push_back(&var);
 			}
@@ -385,26 +272,14 @@ uint32_t CompilerMSL::add_interface_struct(StorageClass storage, uint32_t vtx_bi
 	auto &var = set<SPIRVariable>(ib_var_id, ib_type_id, storage, 0);
 	var.initializer = next_id++;
 
-	// Set the binding of the variable and mark if packed (used only with vertex inputs)
-	auto &var_dec = meta[ib_var_id].decoration;
-	var_dec.binding = vtx_binding;
-
-	// Track whether this is vertex input that is indexed, as opposed to stage_in
-	bool is_indxd_vtx_input = (execution.model == ExecutionModelVertex && storage == StorageClassInput &&
-	                           var_dec.binding != msl_config.vtx_attr_stage_in_binding);
-
 	string ib_var_ref;
-
-	if (storage == StorageClassInput)
+	switch (storage)
 	{
+	case StorageClassInput:
 		ib_var_ref = stage_in_var_name;
+		break;
 
-		// Multiple vertex input bindings are available, so qualify each with the Metal buffer index
-		if (execution.model == ExecutionModelVertex)
-			ib_var_ref += convert_to_string(vtx_binding);
-	}
-
-	if (storage == StorageClassOutput)
+	case StorageClassOutput:
 	{
 		ib_var_ref = stage_out_var_name;
 
@@ -419,92 +294,64 @@ uint32_t CompilerMSL::add_interface_struct(StorageClass storage, uint32_t vtx_bi
 			if (blk.terminator == SPIRBlock::Return)
 				blk.return_value = ib_var_id;
 		}
+		break;
+	}
+
+	default:
+		break;
 	}
 
 	set_name(ib_type_id, get_entry_point_name() + "_" + ib_var_ref);
 	set_name(ib_var_id, ib_var_ref);
 
-	size_t struct_size = 0;
-	bool first_elem = true;
 	for (auto p_var : vars)
 	{
-		// For index-accessed vertex attributes, copy the attribute characteristics to the parent
-		// structure (all components have same vertex attribute characteristics except offset),
-		// and add a reference to the vertex index builtin to the parent struct variable name.
-		if (is_indxd_vtx_input && first_elem)
-		{
-			auto &elem_dec = meta[p_var->self].decoration;
-			var_dec.binding = elem_dec.binding;
-			var_dec.array_stride = elem_dec.array_stride;
-			var_dec.per_instance = elem_dec.per_instance;
-			ib_var_ref += "[" + get_vtx_idx_var_name(var_dec.per_instance) + "]";
-			first_elem = false;
-		}
-
 		uint32_t type_id = p_var->basetype;
 		auto &type = get<SPIRType>(type_id);
 		if (type.basetype == SPIRType::Struct)
 		{
 			// Flatten the struct members into the interface struct
-			uint32_t i = 0;
+			uint32_t mbr_idx = 0;
 			for (auto &member : type.member_types)
 			{
-				// If needed, add a padding member to the struct to align to the next member's offset.
-				uint32_t mbr_offset = get_member_decoration(type_id, i, DecorationOffset);
-				struct_size =
-				    pad_to_offset(ib_type, is_indxd_vtx_input, (var_dec.offset + mbr_offset), uint32_t(struct_size));
-
 				// Add a reference to the member to the interface struct.
 				uint32_t ib_mbr_idx = uint32_t(ib_type.member_types.size());
 				ib_type.member_types.push_back(member); // membertype.self is different for array types
 
-				// Give the member a name, and assign it an offset within the struct.
-				string mbr_name = ensure_valid_name(to_qualified_member_name(type, i), "m");
+				// Give the member a name
+				string mbr_name = ensure_valid_name(to_qualified_member_name(type, mbr_idx), "m");
 				set_member_name(ib_type_id, ib_mbr_idx, mbr_name);
-				set_member_decoration(ib_type_id, ib_mbr_idx, DecorationOffset, uint32_t(struct_size));
-				struct_size = get_declared_struct_size(ib_type);
 
 				// Update the original variable reference to include the structure reference
 				string qual_var_name = ib_var_ref + "." + mbr_name;
-				set_member_qualified_name(type_id, i, qual_var_name);
+				set_member_qualified_name(type_id, mbr_idx, qual_var_name);
 
 				// Copy the variable location from the original variable to the member
-				uint32_t locn = get_member_decoration(type_id, i, DecorationLocation);
+				uint32_t locn = get_member_decoration(type_id, mbr_idx, DecorationLocation);
 				set_member_decoration(ib_type_id, ib_mbr_idx, DecorationLocation, locn);
-
-				// Set vertex binding offsets
-				if (execution.model == ExecutionModelVertex && storage == StorageClassInput)
-				{
-					uint32_t offset = get_member_decoration(type_id, i, DecorationOffset);
-					set_member_decoration(ib_type_id, ib_mbr_idx, DecorationOffset, offset);
-				}
+				mark_location_as_used_by_shader(locn, storage);
 
 				// Mark the member as builtin if needed
 				BuiltIn builtin;
-				if (is_member_builtin(type, i, &builtin))
+				if (is_member_builtin(type, mbr_idx, &builtin))
 				{
 					set_member_decoration(ib_type_id, ib_mbr_idx, DecorationBuiltIn, builtin);
 					if (builtin == BuiltInPosition)
 						qual_pos_var_name = qual_var_name;
 				}
 
-				i++;
+				mbr_idx++;
 			}
 		}
 		else
 		{
-			// If needed, add a padding member to the struct to align to the next member's offset.
-			struct_size = pad_to_offset(ib_type, is_indxd_vtx_input, var_dec.offset, uint32_t(struct_size));
-
 			// Add a reference to the variable type to the interface struct.
 			uint32_t ib_mbr_idx = uint32_t(ib_type.member_types.size());
 			ib_type.member_types.push_back(type_id);
 
-			// Give the member a name, and assign it an offset within the struct.
+			// Give the member a name
 			string mbr_name = ensure_valid_name(to_expression(p_var->self), "m");
 			set_member_name(ib_type_id, ib_mbr_idx, mbr_name);
-			set_member_decoration(ib_type_id, ib_mbr_idx, DecorationOffset, uint32_t(struct_size));
-			struct_size = get_declared_struct_size(ib_type);
 
 			// Update the original variable reference to include the structure reference
 			string qual_var_name = ib_var_ref + "." + mbr_name;
@@ -512,11 +359,9 @@ uint32_t CompilerMSL::add_interface_struct(StorageClass storage, uint32_t vtx_bi
 
 			// Copy the variable location from the original variable to the member
 			auto &dec = meta[p_var->self].decoration;
-			set_member_decoration(ib_type_id, ib_mbr_idx, DecorationLocation, dec.location);
-
-			// Set vertex binding offsets
-			if (execution.model == ExecutionModelVertex && storage == StorageClassInput)
-				set_member_decoration(ib_type_id, ib_mbr_idx, DecorationOffset, dec.offset);
+			uint32_t locn = dec.location;
+			set_member_decoration(ib_type_id, ib_mbr_idx, DecorationLocation, locn);
+			mark_location_as_used_by_shader(locn, storage);
 
 			// Mark the member as builtin if needed
 			if (is_builtin_variable(*p_var))
@@ -616,12 +461,8 @@ void CompilerMSL::emit_resources()
 	}
 
 	// Output interface blocks.
-	for (uint32_t var_id : stage_in_var_ids)
-		emit_interface_block(var_id);
-
+	emit_interface_block(stage_in_var_id);
 	emit_interface_block(stage_out_var_id);
-
-	// TODO: Consolidate and output loose uniforms into an input struct
 }
 
 // Override for MSL-specific syntax instructions
@@ -1370,26 +1211,18 @@ string CompilerMSL::clean_func_name(string func_name)
 // Returns a string containing a comma-delimited list of args for the entry point function
 string CompilerMSL::entry_point_args(bool append_comma)
 {
-	auto &execution = get_entry_point();
 	string ep_args;
 
-	// Stage-in structures
-	for (uint32_t var_id : stage_in_var_ids)
+	// Stage-in structure
+	if (stage_in_var_id)
 	{
-		auto &var = get<SPIRVariable>(var_id);
+		auto &var = get<SPIRVariable>(stage_in_var_id);
 		auto &type = get<SPIRType>(var.basetype);
-		auto &dec = meta[var.self].decoration;
-
-		bool use_stage_in =
-		    (execution.model != ExecutionModelVertex || dec.binding == msl_config.vtx_attr_stage_in_binding);
 
 		if (!ep_args.empty())
 			ep_args += ", ";
-		if (use_stage_in)
-			ep_args += type_to_glsl(type) + " " + to_name(var.self) + " [[stage_in]]";
-		else
-			ep_args += "device " + type_to_glsl(type) + "* " + to_name(var.self) + " [[buffer(" +
-			           convert_to_string(dec.binding) + ")]]";
+
+		ep_args += type_to_glsl(type) + " " + to_name(var.self) + " [[stage_in]]";
 	}
 
 	// Uniforms
@@ -1506,65 +1339,6 @@ uint32_t CompilerMSL::get_metal_resource_index(SPIRVariable &var, SPIRType::Base
 string CompilerMSL::get_entry_point_name()
 {
 	return clean_func_name(to_name(entry_point));
-}
-
-// Returns the name of either the vertex index or instance index builtin
-string CompilerMSL::get_vtx_idx_var_name(bool per_instance)
-{
-	BuiltIn builtin;
-	uint32_t var_id;
-
-	// Try modern builtin name first
-	builtin = per_instance ? BuiltInInstanceIndex : BuiltInVertexIndex;
-	var_id = builtin_vars[builtin];
-	if (var_id)
-		return to_expression(var_id);
-
-	// Try legacy builtin name second
-	builtin = per_instance ? BuiltInInstanceId : BuiltInVertexId;
-	var_id = builtin_vars[builtin];
-	if (var_id)
-		return to_expression(var_id);
-
-	return "missing_vtx_idx_var";
-}
-
-// If the struct contains indexed vertex input, and the offset is greater than the current
-// size of the struct, appends a padding member to the struct, and returns the offset to
-// use for the next member, which is the offset provided. Otherwise, no padding is added,
-// and the struct size is returned.
-uint32_t CompilerMSL::pad_to_offset(SPIRType &struct_type, bool is_indxd_vtx_input, uint32_t offset,
-                                    uint32_t struct_size)
-{
-	if (!(is_indxd_vtx_input && offset > struct_size))
-		return struct_size;
-
-	auto &pad_type = get_pad_type(offset - struct_size);
-	uint32_t mbr_idx = uint32_t(struct_type.member_types.size());
-	struct_type.member_types.push_back(pad_type.self);
-	set_member_name(struct_type.self, mbr_idx, ("pad" + convert_to_string(mbr_idx)));
-	set_member_decoration(struct_type.self, mbr_idx, DecorationOffset, struct_size);
-	return offset;
-}
-
-// Returns a char array type suitable for use as a padding member in a packed struct
-SPIRType &CompilerMSL::get_pad_type(uint32_t pad_len)
-{
-	uint32_t pad_type_id = pad_type_ids_by_pad_len[pad_len];
-	if (pad_type_id != 0)
-		return get<SPIRType>(pad_type_id);
-
-	pad_type_id = increase_bound_by(1);
-	auto &ib_type = set<SPIRType>(pad_type_id);
-	ib_type.storage = StorageClassGeneric;
-	ib_type.basetype = SPIRType::Char;
-	ib_type.width = 8;
-	ib_type.array.push_back(pad_len);
-	ib_type.array_size_literal.push_back(true);
-	set_decoration(ib_type.self, DecorationArrayStride, pad_len);
-
-	pad_type_ids_by_pad_len[pad_len] = pad_type_id;
-	return ib_type;
 }
 
 string CompilerMSL::argument_decl(const SPIRFunction::Parameter &arg)

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -28,14 +28,14 @@ CompilerMSL::CompilerMSL(vector<uint32_t> spirv_)
 {
 	options.vertex.fixup_clipspace = false;
 
-    populate_func_name_overrides();
+	populate_func_name_overrides();
 }
 
 // Populate the collection of function names that need to be overridden
 void CompilerMSL::populate_func_name_overrides()
 {
-    func_name_overrides["main"] = "main0";
-    func_name_overrides["saturate"] = "saturate0";
+	func_name_overrides["main"] = "main0";
+	func_name_overrides["saturate"] = "saturate0";
 }
 
 string CompilerMSL::compile(MSLConfiguration &msl_cfg, vector<MSLVertexAttr> *p_vtx_attrs,
@@ -708,8 +708,8 @@ void CompilerMSL::emit_function_prototype(SPIRFunction &func, bool is_decl)
 }
 
 // Returns the texture sampling function string for the specified image and sampling characteristics.
-string CompilerMSL::to_function_name(uint32_t img, const SPIRType &, bool is_fetch, bool is_gather,
-                                     bool, bool, bool, bool, bool, bool has_dref)
+string CompilerMSL::to_function_name(uint32_t img, const SPIRType &, bool is_fetch, bool is_gather, bool, bool, bool,
+                                     bool, bool, bool has_dref)
 {
 	// Texture reference
 	string fname = to_expression(img) + ".";
@@ -1212,8 +1212,8 @@ string CompilerMSL::func_type_decl(SPIRType &type)
 // Ensures the function name is not "main", which is illegal in MSL
 string CompilerMSL::clean_func_name(string func_name)
 {
-    auto iter = func_name_overrides.find(func_name);
-    return (iter != func_name_overrides.end()) ? iter->second : func_name;
+	auto iter = func_name_overrides.find(func_name);
+	return (iter != func_name_overrides.end()) ? iter->second : func_name;
 }
 
 // Returns a string containing a comma-delimited list of args for the entry point function

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -164,6 +164,7 @@ protected:
 	std::string stage_out_var_name = "out";
     std::string stage_uniform_var_name = "uniforms";
 	std::string sampler_name_suffix = "Smplr";
+    std::vector<std::string> reserved_names = {"kernel", "bias"};
 };
 
 // Sorts the members of a SPIRType and associated Meta info based on a settable sorting

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -122,6 +122,9 @@ protected:
 	void extract_global_variables_from_function(uint32_t func_id, std::set<uint32_t> &added_arg_ids,
 	                                            std::set<uint32_t> &global_var_ids,
 	                                            std::set<uint32_t> &processed_func_ids);
+    
+    std::unordered_map<uint32_t, std::set<uint32_t>> function_global_vars;
+    
 	void add_interface_structs();
 	void bind_vertex_attributes(std::set<uint32_t> &bindings);
 	uint32_t add_interface_struct(spv::StorageClass storage, uint32_t vtx_binding = 0);

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -28,8 +28,8 @@ namespace spirv_cross
 struct MSLConfiguration
 {
 	uint32_t vtx_attr_stage_in_binding = 0;
-	bool flip_vert_y = true;
-	bool flip_frag_y = true;
+	bool flip_vert_y = false;
+	bool flip_frag_y = false;
 	bool is_rendering_points = false;
 };
 

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -155,9 +155,11 @@ protected:
 	std::unordered_map<uint32_t, uint32_t> pad_type_ids_by_pad_len;
 	std::vector<uint32_t> stage_in_var_ids;
 	uint32_t stage_out_var_id = 0;
+    uint32_t stage_uniforms_var_id = 0;
 	std::string qual_pos_var_name;
 	std::string stage_in_var_name = "in";
 	std::string stage_out_var_name = "out";
+    std::string stage_uniform_var_name = "uniforms";
 	std::string sampler_name_suffix = "Smplr";
 };
 

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -175,6 +175,7 @@ struct MemberSorter
 	{
 		Location,
 		Offset,
+        Alphabetical
 	};
 
 	void sort();

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -94,6 +94,8 @@ public:
 
 	// Compiles the SPIR-V code into Metal Shading Language using default configuration parameters.
 	std::string compile() override;
+    
+    void set_func_name(std::string func_name);
 
 protected:
 	void emit_instruction(const Instruction &instr) override;
@@ -129,6 +131,7 @@ protected:
 	void emit_function_declarations();
 
 	std::string func_type_decl(SPIRType &type);
+    std::string _clean_msl_main_func_name;
 	std::string clean_func_name(std::string func_name);
 	std::string entry_point_args(bool append_comma);
 	std::string get_entry_point_name();

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -18,6 +18,7 @@
 #define SPIRV_CROSS_MSL_HPP
 
 #include "spirv_glsl.hpp"
+#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
@@ -113,6 +114,8 @@ protected:
 	std::string to_func_call_arg(uint32_t id) override;
 	std::string to_name(uint32_t id, bool allow_alias = true) override;
 
+	void register_custom_functions();
+	void emit_custom_functions();
 	void extract_builtins();
 	void add_builtin(spv::BuiltIn builtin_type);
 	void localize_global_variables();
@@ -148,6 +151,7 @@ protected:
 	size_t get_declared_type_size(uint32_t type_id, uint64_t dec_mask) const;
 
 	MSLConfiguration msl_config;
+	std::unordered_set<uint32_t> custom_function_ops;
 	std::unordered_map<uint32_t, MSLVertexAttr *> vtx_attrs_by_location;
 	std::vector<MSLResourceBinding *> resource_bindings;
 	std::unordered_map<uint32_t, uint32_t> builtin_vars;

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -104,7 +104,6 @@ protected:
 	void emit_header() override;
 	void emit_function_prototype(SPIRFunction &func, uint64_t return_flags) override;
 	void emit_sampled_image_op(uint32_t result_type, uint32_t result_id, uint32_t image_id, uint32_t samp_id) override;
-	void emit_texture_op(const Instruction &i) override;
 	void emit_fixup() override;
 	std::string type_to_glsl(const SPIRType &type) override;
 	std::string image_type_glsl(const SPIRType &type) override;
@@ -114,6 +113,13 @@ protected:
 	size_t get_declared_struct_member_size(const SPIRType &struct_type, uint32_t index) const override;
 	std::string to_func_call_arg(uint32_t id) override;
 	std::string to_name(uint32_t id, bool allow_alias = true) override;
+	std::string to_function_name(uint32_t img, const SPIRType &imgtype, bool is_fetch, bool is_gather, bool is_proj,
+	                             bool has_array_offsets, bool has_offset, bool has_grad, bool has_lod,
+	                             bool has_dref) override;
+	std::string to_function_args(uint32_t img, const SPIRType &imgtype, bool is_fetch, bool is_gather, bool is_proj,
+	                             uint32_t coord, uint32_t coord_components, uint32_t dref, uint32_t grad_x,
+	                             uint32_t grad_y, uint32_t lod, uint32_t coffset, uint32_t offset, uint32_t bias,
+	                             uint32_t comp, uint32_t sample, bool *p_forward) override;
 
 	void register_custom_functions();
 	void emit_custom_functions();
@@ -150,6 +156,7 @@ protected:
 	SPIRType &get_pad_type(uint32_t pad_len);
 	size_t get_declared_type_size(uint32_t type_id) const;
 	size_t get_declared_type_size(uint32_t type_id, uint64_t dec_mask) const;
+	std::string to_component_argument(uint32_t id);
 
 	MSLConfiguration msl_config;
 	std::set<uint32_t> custom_function_ops;

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -115,6 +115,7 @@ protected:
 	                             uint32_t coord, uint32_t coord_components, uint32_t dref, uint32_t grad_x,
 	                             uint32_t grad_y, uint32_t lod, uint32_t coffset, uint32_t offset, uint32_t bias,
 	                             uint32_t comp, uint32_t sample, bool *p_forward) override;
+    std::string clean_func_name(std::string func_name) override;
 
 	void register_custom_functions();
 	void emit_custom_functions();
@@ -129,9 +130,9 @@ protected:
 	void emit_interface_block(uint32_t ib_var_id);
 	void emit_function_prototype(SPIRFunction &func, bool is_decl);
 	void emit_function_declarations();
+    void populate_func_name_overrides();
 
 	std::string func_type_decl(SPIRType &type);
-	std::string clean_func_name(std::string func_name);
 	std::string entry_point_args(bool append_comma);
 	std::string get_entry_point_name();
 	std::string to_qualified_member_name(const SPIRType &type, uint32_t index);
@@ -148,6 +149,7 @@ protected:
 	std::string to_component_argument(uint32_t id);
 
 	MSLConfiguration msl_config;
+    std::unordered_map<std::string,std::string> func_name_overrides;
 	std::set<uint32_t> custom_function_ops;
 	std::unordered_map<uint32_t, MSLVertexAttr *> vtx_attrs_by_location;
 	std::vector<MSLResourceBinding *> resource_bindings;

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -115,7 +115,7 @@ protected:
 	                             uint32_t coord, uint32_t coord_components, uint32_t dref, uint32_t grad_x,
 	                             uint32_t grad_y, uint32_t lod, uint32_t coffset, uint32_t offset, uint32_t bias,
 	                             uint32_t comp, uint32_t sample, bool *p_forward) override;
-    std::string clean_func_name(std::string func_name) override;
+	std::string clean_func_name(std::string func_name) override;
 
 	void register_custom_functions();
 	void emit_custom_functions();
@@ -130,7 +130,7 @@ protected:
 	void emit_interface_block(uint32_t ib_var_id);
 	void emit_function_prototype(SPIRFunction &func, bool is_decl);
 	void emit_function_declarations();
-    void populate_func_name_overrides();
+	void populate_func_name_overrides();
 
 	std::string func_type_decl(SPIRType &type);
 	std::string entry_point_args(bool append_comma);
@@ -149,7 +149,7 @@ protected:
 	std::string to_component_argument(uint32_t id);
 
 	MSLConfiguration msl_config;
-    std::unordered_map<std::string,std::string> func_name_overrides;
+	std::unordered_map<std::string, std::string> func_name_overrides;
 	std::set<uint32_t> custom_function_ops;
 	std::unordered_map<uint32_t, MSLVertexAttr *> vtx_attrs_by_location;
 	std::vector<MSLResourceBinding *> resource_bindings;

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -29,7 +29,6 @@ namespace spirv_cross
 // Options for compiling to Metal Shading Language
 struct MSLConfiguration
 {
-	uint32_t vtx_attr_stage_in_binding = 0;
 	bool flip_vert_y = true;
 	bool flip_frag_y = true;
 	bool is_rendering_points = false;
@@ -41,10 +40,6 @@ struct MSLConfiguration
 struct MSLVertexAttr
 {
 	uint32_t location = 0;
-	uint32_t msl_buffer = 0;
-	uint32_t msl_offset = 0;
-	uint32_t msl_stride = 0;
-	bool per_instance = false;
 	bool used_by_shader = false;
 };
 
@@ -123,16 +118,13 @@ protected:
 
 	void register_custom_functions();
 	void emit_custom_functions();
-	void extract_builtins();
-	void add_builtin(spv::BuiltIn builtin_type);
 	void localize_global_variables();
 	void extract_global_variables_from_functions();
 	void extract_global_variables_from_function(uint32_t func_id, std::unordered_set<uint32_t> &added_arg_ids,
 	                                            std::unordered_set<uint32_t> &global_var_ids,
 	                                            std::unordered_set<uint32_t> &processed_func_ids);
-	void add_interface_structs();
-	void bind_vertex_attributes(std::unordered_set<uint32_t> &bindings);
-	uint32_t add_interface_struct(spv::StorageClass storage, uint32_t vtx_binding = 0);
+	uint32_t add_interface_block(spv::StorageClass storage);
+	void mark_location_as_used_by_shader(uint32_t location, spv::StorageClass storage);
 	void emit_resources();
 	void emit_interface_block(uint32_t ib_var_id);
 	void emit_function_prototype(SPIRFunction &func, bool is_decl);
@@ -149,11 +141,8 @@ protected:
 	std::string builtin_type_decl(spv::BuiltIn builtin);
 	std::string member_attribute_qualifier(const SPIRType &type, uint32_t index);
 	std::string argument_decl(const SPIRFunction::Parameter &arg);
-	std::string get_vtx_idx_var_name(bool per_instance);
 	uint32_t get_metal_resource_index(SPIRVariable &var, SPIRType::BaseType basetype);
 	uint32_t get_ordered_member_location(uint32_t type_id, uint32_t index);
-	uint32_t pad_to_offset(SPIRType &struct_type, bool is_indxd_vtx_input, uint32_t offset, uint32_t struct_size);
-	SPIRType &get_pad_type(uint32_t pad_len);
 	size_t get_declared_type_size(uint32_t type_id) const;
 	size_t get_declared_type_size(uint32_t type_id, uint64_t dec_mask) const;
 	std::string to_component_argument(uint32_t id);
@@ -162,10 +151,8 @@ protected:
 	std::set<uint32_t> custom_function_ops;
 	std::unordered_map<uint32_t, MSLVertexAttr *> vtx_attrs_by_location;
 	std::vector<MSLResourceBinding *> resource_bindings;
-	std::unordered_map<uint32_t, uint32_t> builtin_vars;
 	MSLResourceBinding next_metal_resource_index;
-	std::unordered_map<uint32_t, uint32_t> pad_type_ids_by_pad_len;
-	std::vector<uint32_t> stage_in_var_ids;
+	uint32_t stage_in_var_id = 0;
 	uint32_t stage_out_var_id = 0;
 	std::string qual_pos_var_name;
 	std::string stage_in_var_name = "in";

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -144,8 +144,8 @@ protected:
 	uint32_t get_ordered_member_location(uint32_t type_id, uint32_t index);
 	uint32_t pad_to_offset(SPIRType &struct_type, bool is_indxd_vtx_input, uint32_t offset, uint32_t struct_size);
 	SPIRType &get_pad_type(uint32_t pad_len);
-	size_t get_declared_type_size(const SPIRType &type) const;
-	size_t get_declared_type_size(const SPIRType &type, uint64_t dec_mask) const;
+	size_t get_declared_type_size(uint32_t type_id) const;
+	size_t get_declared_type_size(uint32_t type_id, uint64_t dec_mask) const;
 
 	MSLConfiguration msl_config;
 	std::unordered_map<uint32_t, MSLVertexAttr *> vtx_attrs_by_location;

--- a/spirv_msl.hpp
+++ b/spirv_msl.hpp
@@ -18,7 +18,7 @@
 #define SPIRV_CROSS_MSL_HPP
 
 #include "spirv_glsl.hpp"
-#include <set>
+#include <unordered_set>
 #include <vector>
 
 namespace spirv_cross
@@ -117,11 +117,11 @@ protected:
 	void add_builtin(spv::BuiltIn builtin_type);
 	void localize_global_variables();
 	void extract_global_variables_from_functions();
-	void extract_global_variables_from_function(uint32_t func_id, std::set<uint32_t> &added_arg_ids,
-	                                            std::set<uint32_t> &global_var_ids,
-	                                            std::set<uint32_t> &processed_func_ids);
+	void extract_global_variables_from_function(uint32_t func_id, std::unordered_set<uint32_t> &added_arg_ids,
+	                                            std::unordered_set<uint32_t> &global_var_ids,
+	                                            std::unordered_set<uint32_t> &processed_func_ids);
 	void add_interface_structs();
-	void bind_vertex_attributes(std::set<uint32_t> &bindings);
+	void bind_vertex_attributes(std::unordered_set<uint32_t> &bindings);
 	uint32_t add_interface_struct(spv::StorageClass storage, uint32_t vtx_binding = 0);
 	void emit_resources();
 	void emit_interface_block(uint32_t ib_var_id);
@@ -169,7 +169,9 @@ struct MemberSorter
 	enum SortAspect
 	{
 		Location,
+		LocationReverse,
 		Offset,
+		OffsetThenLocationReverse,
 	};
 
 	void sort();


### PR DESCRIPTION
Implemented:
- uniform struct
- increase attribute index to identify each vertex input
- shader signature matching (e.g. [[user(locn0)]])
